### PR TITLE
Issue #9: citing regtext paragraphs from within interpretations

### DIFF
--- a/parser/layer/internal_citations.py
+++ b/parser/layer/internal_citations.py
@@ -23,6 +23,9 @@ class InternalCitationParser(Layer):
     def regtext_citations(self, text, parts):
         """Find all citations that refer to regtext"""
         citations = []
+        #   If referring to a specific paragraph using regtext notation, we
+        #   are not discussing an interp paragraph; use the associated regtext
+        paragraph_parts = [p for p in parts if p != 'Interpretations']
         for citation, start, end in grammar.regtext_citation.scanString(text):
             if citation.single_paragraph or citation.multiple_paragraphs:
                 if citation.single_paragraph:
@@ -30,7 +33,7 @@ class InternalCitationParser(Layer):
                 else:
                     citation = citation.multiple_paragraphs
                 citations.extend(self.paragraph_list(citation, 
-                    citation.p_head.pos[0], end, parts[0:2]))
+                    citation.p_head.pos[0], end, paragraph_parts[0:2]))
             elif citation.multiple_sections:
                 sections = [citation.s_head] + list(citation.s_tail)
                 for section in sections:

--- a/tests/internal_citation_parse.py
+++ b/tests/internal_citation_parse.py
@@ -253,3 +253,13 @@ class ParseTest(TestCase):
             '1'], result[1]['citation'])
         offsets = result[1]['offsets'][0]
         self.assertEqual('31(b)(1)(vi)-1', text[offsets[0]:offsets[1]])
+
+    def test_paren_in_interps(self):
+        text = "covers everything except paragraph (d)(3)(i) of this section"
+        result = self.parser.parse(text, 
+                parts = ['222', 'Interpretations', '87'])
+        self.assertEqual(1, len(result))
+        self.assertEqual(['222', '87', 'd', '3', 'i'], result[0]['citation'])
+        offsets = result[0]['offsets'][0]
+        self.assertEqual('(d)(3)(i)', text[offsets[0]:offsets[1]])
+


### PR DESCRIPTION
Whenever we say "paragraph (z)" or "paragraph (q)(4)", we use the context of the current paragraph to determine to what this is referring. This context isn't quite accurate with interpretations, however, since the paren format doesn't apply to interpretations. This does the logical thing and points to the associated regtext paragraph.
