### PR TITLE
Fix for #54, missing defs

### DIFF
--- a/parser/layer/terms.py
+++ b/parser/layer/terms.py
@@ -87,7 +87,7 @@ class Terms(Layer):
         larger (i.e. containing) terms."""
 
         #   longer terms first
-        applicable_terms.sort(key=lambda x: x[0], reverse=True)
+        applicable_terms.sort(key=lambda x: len(x[0]), reverse=True)
 
         matches = []
         existing_defs = []

--- a/tests/layer_terms.py
+++ b/tests/layer_terms.py
@@ -38,7 +38,6 @@ class LayerTermTest(TestCase):
             struct.label('88-20-a', ['88', '20', 'a']))
         self.assertTrue(t.has_definitions(node))
 
-
     def test_node_definitions(self):
         t = Terms(None)
         text1 = u'This has a “worD” and then more'
@@ -124,7 +123,7 @@ class LayerTermTest(TestCase):
         matches = t.calculate_offsets(text, applicable_terms)
         self.assertEqual(3, len(matches))
         found = [False, False, False]
-        for term, ref, offsets in matches:
+        for _, ref, offsets in matches:
             if ref == 'a' and offsets == [(10,19)]:
                 found[0] = True
             if ref == 'b' and offsets == [(30,34)]:
@@ -132,6 +131,16 @@ class LayerTermTest(TestCase):
             if ref == 'c' and offsets == [(42,46), (55,59)]:
                 found[2] = True
         self.assertEqual([True,True,True], found)
+
+    def test_calculate_offsets_lexical_container(self):
+        applicable_terms = [('access device', 'a'), ('device', 'd')]
+        text = "This access device is fantastic!"
+        t = Terms(None)
+        matches = t.calculate_offsets(text, applicable_terms)
+        self.assertEqual(1, len(matches))
+        _, ref, offsets = matches[0]
+        self.assertEqual('a', ref)
+        self.assertEqual([(5,18)], offsets)
 
     def test_calculate_offsets_word_part(self):
         """If a defined term is part of another word, don't include it"""


### PR DESCRIPTION
This pays attention to "definition" nodes that begin with a paragraph marker and fixes the logic which causes longer terms (which may contain shorter terms) to be processed first.
