### PR TITLE
Fix flat interpretation hierarchy

### DIFF
--- a/regparser/tree/interpretation.py
+++ b/regparser/tree/interpretation.py
@@ -2,7 +2,7 @@ from regparser import utils
 from regparser.grammar.internal_citations import comment_citation
 import regparser.grammar.interpretation_headers as grammar
 from regparser.tree.paragraph import ParagraphParser
-from regparser.tree.struct import Node
+from regparser.tree.struct import Node, treeify
 
 
 #   Can only be preceded by white space or a start of line
@@ -17,8 +17,8 @@ def build(text, part):
 
     if segments:
         children = [segment_tree(body[s:e], part, [part]) for s,e in segments]
-        return Node(body[:segments[0][0]], children, [part, Node.INTERP_MARK], 
-                title, Node.INTERP)
+        return Node(body[:segments[0][0]], treeify(children), 
+                [part, Node.INTERP_MARK], title, Node.INTERP)
     else:
         return Node(body, [], [part, Node.INTERP_MARK], title,
                 Node.INTERP)

--- a/regparser/tree/struct.py
+++ b/regparser/tree/struct.py
@@ -15,12 +15,15 @@ class Node:
         title = unicode(title or '')
         self.title = title or None
         self.node_type = node_type
+
     def __repr__(self):
         return (("Node( text = %s, children = %s, label = %s, title = %s, "
             + "node_type = %s)") % (repr(self.text), repr(self.children), 
                 repr(self.label), repr(self.title), repr(self.node_type)))
+
     def __cmp__(self, other):
         return cmp(repr(self), repr(other))
+
     def label_id(self):
         return '-'.join(self.label)
 
@@ -73,3 +76,31 @@ def join_text(node):
     bits = []
     walk(node, lambda n: bits.append(n.text))
     return ''.join(bits)
+
+
+def treeify(nodes):
+    """Given a list of nodes, convert those nodes into the appropriate tree
+    structure based on their labels. This assumes that all nodes will fall
+    under a set of 'root' nodes, which have the min-length label."""
+    if not nodes:
+        return nodes
+    
+    min_len, with_min = len(nodes[0].label), []
+
+    for node in nodes:
+        if len(node.label) == min_len:
+            with_min.append(node)
+        elif len(node.label) < min_len:
+            min_len = len(node.label)
+            with_min = [node]
+
+    roots = []
+    for root in with_min:
+        if root.label[-1] == Node.INTERP_MARK:
+            is_child = lambda n: n.label[:len(root.label)-1] == root.label[:-1]
+        else:
+            is_child = lambda n: n.label[:len(root.label)] == root.label
+        children = [n for n in nodes if n != root and is_child(n)]
+        root.children = root.children + treeify(children)
+        roots.append(root)
+    return roots

--- a/tests/tree_build.py
+++ b/tests/tree_build.py
@@ -52,14 +52,21 @@ class TreeBuildTest(TestCase):
             children=[
                 Node('\n', label=['200', '2', Node.INTERP_MARK], 
                     node_type=Node.INTERP,
-                    title='Section 200.2 Second section'),
-                Node('\n', label=['200','2','a','5',Node.INTERP_MARK],
-                    node_type=Node.INTERP, title='2(a)(5) First par',
-                    children=[
-                        Node('1. Commentary 1\n', node_type=Node.INTERP,
-                            label=['200','2','a','5',Node.INTERP_MARK,'1']),
-                        Node('2. Commentary 2\n', node_type=Node.INTERP,
-                            label=['200','2','a','5',Node.INTERP_MARK,'2'])
+                    title='Section 200.2 Second section',
+                    children = [ 
+                        Node('\n', label=['200','2','a','5',Node.INTERP_MARK],
+                            node_type=Node.INTERP, title='2(a)(5) First par',
+                            children=[
+                                Node('1. Commentary 1\n', 
+                                    node_type = Node.INTERP, 
+                                    label = ['200', '2', 'a', '5',
+                                        Node.INTERP_MARK, '1']),
+                                Node('2. Commentary 2\n', 
+                                    node_type = Node.INTERP,
+                                    label = ['200', '2', 'a', '5',
+                                        Node.INTERP_MARK, '2'])
+                            ]
+                        )
                     ]
                 )
             ]

--- a/tests/tree_interpretation_tests.py
+++ b/tests/tree_interpretation_tests.py
@@ -82,6 +82,23 @@ class DepthInterpretationTreeTest(TestCase):
         self.assertEqual(['100', '5', Node.INTERP_MARK], node.label)
         self.assertEqual(0, len(node.children))
 
+    def test_build_interp_headers(self):
+        text = "\nSection 876.2 Definitions\n\n2(r) Def1\n\n2(r)(4) SubSub"
+        result = build(text, "876")
+
+        self.assertEqual(['876', Node.INTERP_MARK], result.label)
+        self.assertEqual(1, len(result.children))
+
+        child = result.children[0]
+        self.assertEqual(['876', '2', Node.INTERP_MARK], child.label)
+        self.assertEqual(1, len(child.children))
+
+        child = child.children[0]
+        self.assertEqual(['876', '2', 'r', Node.INTERP_MARK], child.label)
+        self.assertEqual(1, len(child.children))
+
+        child = child.children[0]
+        self.assertEqual(['876','2','r','4',Node.INTERP_MARK], child.label)
 
     def test_segment_tree_appendix(self):
         title = "Appendix Q - The Questions"

--- a/tests/tree_struct.py
+++ b/tests/tree_struct.py
@@ -86,3 +86,44 @@ class DepthTreeTest(TestCase):
                 'children': [1,2,3], 'title': 'Example Title'}
         self.assertEqual(Node('t', [1,2,3], [2,3,4], 'Example Title', u'ttt'), 
             json.loads(json.dumps(d), object_hook=node_decode_hook))
+
+    def test_treeify(self):
+        n1 = Node(label=['1'])
+        n1b = Node(label=['1', 'b'])
+        n1b5 = Node(label=['1', 'b', '5'])
+
+        n2 = Node(label=['2'])
+
+        result = treeify([n1, n1b5, n2, n1b])
+        self.assertEqual(sorted(result), sorted([
+            Node(label=['1'], children=[
+                Node(label=['1', 'b'], children=[
+                    Node(label=['1', 'b', '5'])
+                ])
+            ]),
+            Node(label=['2'])
+        ]))
+
+    def test_treeify_interp(self):
+        n1 = Node(label=['1', 'Interp'])
+        n1b = Node(label=['1', 'b', 'Interp'])
+        n1b5 = Node(label=['1', 'b', '5', 'Interp'])
+
+        result = treeify([n1, n1b, n1b5])
+        self.assertEqual(result, [
+            Node(label=['1', 'Interp'], children=[
+                Node(label=['1', 'b', 'Interp'], children=[
+                    Node(label=['1', 'b', '5', 'Interp'])
+                ])
+            ])
+        ])
+
+    def test_treeify_keep_children(self):
+        n1 = Node(label=['1'])
+        n1b = Node(label=['1', 'b'], children=[1,2,3])
+
+        self.assertEqual(treeify([n1, n1b]), [
+            Node(label=['1'], children = [
+                Node(label=['1', 'b'], children=[1,2,3])
+            ])
+        ])


### PR DESCRIPTION
A previous pull request caused all headers of the interpretation to appear as children of the root interpretation. This patch fixes that by building a proper tree for these interpretations.
