### PR TITLE
Fixing table of contents, since we've added subparts

### DIFF
--- a/regparser/layer/table_of_contents.py
+++ b/regparser/layer/table_of_contents.py
@@ -1,20 +1,39 @@
+#vim: set encoding=utf-8
 from layer import Layer
+from regparser.tree.struct import Node
+
 
 class TableOfContentsLayer(Layer):
 
+    def node_is_subpart(self, n):
+        return n.node_type == Node.SUBPART or n.node_type == Node.EMPTYPART
+
     def check_toc_candidacy(self, node):
-        """ To be eligible to contain a table of contents, all of a node's children must 
-        have a title element. """
+        """ To be eligible to contain a table of contents, all of a node's
+        children must have a title element. If one of the children is a
+        subpart, we check all it's children.  """
 
         for c in node.children:
-            if not c.title:
+            if self.node_is_subpart(c):
+                for s in c.children:
+                    if not s.title:
+                        return False
+            elif not c.title:
                 return False
         return True
-            
+
     def process(self, node):
-        if self.check_toc_candidacy(node):                
+        """ Create a table of contents for this node, if it's eligible. We
+        ignore subparts. """
+
+        if self.check_toc_candidacy(node):
             layer_element = []
             for c in node.children:
-                layer_element.append({'index':c.label, 'title':c.title})
+                if self.node_is_subpart(c):
+                    for s in c.children:
+                        layer_element.append(
+                            {'index': s.label, 'title': s.title})
+                else:
+                    layer_element.append({'index': c.label, 'title': c.title})
             return layer_element
         return None

--- a/tests/table_of_contents.py
+++ b/tests/table_of_contents.py
@@ -41,3 +41,24 @@ class TocTest(TestCase):
         self.assertEquals(toc_layer.keys(), ['1005-A'])
         self.assertEqual(len(toc_layer['1005-A']), 3)
         self.assertEqual(toc_layer['1005-A'][0]['index'], ['1005', 'A', '2'])
+
+    def test_toc_with_subparts(self):
+        c1 = Node(label=['205', '2'], title='Authority and Purpose')
+        c2 = Node(label=['205', '3'], title='Definitions')
+        c3 = Node(label=['205', '4'], title='Coverage')
+
+        s1 = Node(children=[c1, c2, c3],
+            label=['205', 'Subpart', 'A'], title='First Subpart', node_type=Node.SUBPART)
+
+        c4 = Node(label=['205', '5'], title='Fifth Title')
+        s2 = Node(children=[c4],
+            label=['205', 'Subpart', 'B'], title='Second Subpart', node_type=Node.SUBPART)
+
+        n = Node(children=[s1, s2], label=['205'])
+        parser = table_of_contents.TableOfContentsLayer(None)
+        toc = parser.process(n)
+        self.assertEquals(len(toc), 4)
+        self.assertEquals(toc[0]['index'], ['205', '2'])
+        self.assertEquals(toc[1]['index'], ['205', '3'])
+        self.assertEquals(toc[2]['index'], ['205', '4'])
+        self.assertEquals(toc[3]['index'], ['205', '5'])


### PR DESCRIPTION
This essentially pretends that the subparts don't exist when generating the TOC for the root node. 
