### PR TITLE
Fixing delete opcodes

### DIFF
--- a/regparser/diff/treediff.py
+++ b/regparser/diff/treediff.py
@@ -6,6 +6,7 @@ DELETE = 'delete'
 REPLACE = 'replace'
 EQUAL = 'equal'
 
+
 def hash_nodes(reg_tree):
     """ Create a hash map to the nodes of a regulation tree.  """
     tree_hash = {}
@@ -29,7 +30,7 @@ def convert_opcode(op, new_text):
     if code == INSERT:
         return convert_insert(op, new_text)
     elif code == DELETE:
-        #Deletes have an extra set of co-ordinates which 
+        #Deletes have an extra set of co-ordinates which
         #we don't need.
         return (DELETE, op[1], op[2])
     elif code == REPLACE:
@@ -66,7 +67,7 @@ def node_to_dict(node):
 class Compare(object):
     """ Compare two regulation trees. """
 
-    #Operations on nodes. 
+    #Operations on nodes.
     ADDED = 'added'
     MODIFIED = 'modified'
     DELETED = 'deleted'
@@ -86,7 +87,9 @@ class Compare(object):
             if label in self.changes:
                 self.changes[label]["title"] = opcodes
             else:
-                self.changes[label] = {"op": Compare.MODIFIED, "title": opcodes}
+                self.changes[label] = {
+                    "op": Compare.MODIFIED,
+                    "title": opcodes}
 
     def add_text_opcodes(self, label, opcodes):
         """ If the text has changed, add those operation codes. """

--- a/tests/diff_treediff.py
+++ b/tests/diff_treediff.py
@@ -1,8 +1,6 @@
 #vim: set encoding=utf-8
 from unittest import TestCase
 
-import difflib
-
 from regparser.tree import reg_text
 from regparser.diff import treediff
 
@@ -52,7 +50,6 @@ class TreeDiffTest(TestCase):
             [('delete', 0, 2)], codes)
 
     def test_convert_insert(self):
-        old = 'acbd'
         new = 'ac ef bd'
         op = ('insert', 2, 2, 2, 6)
         converted = treediff.convert_insert(op, new)


### PR DESCRIPTION
When we passed through the opcodes for delete from difflib, the difflib opcodes have 4 offset co-ordinates. We change this to the two co-ordinates that are important. 
