### PR TITLE
Partially handle plain-text versions of level 5 paragraphs

### DIFF
--- a/regparser/grammar/common.py
+++ b/regparser/grammar/common.py
@@ -34,6 +34,12 @@ em_digit_p = (
     Suppress(Regex(r"\(<E[^>]*>"))
     + Word(string.digits).setResultsName("level5")
     + Suppress("</E>)"))
+# Our support for italicized paragraph markers isn't quite up to par yet;
+# allow a plaintext version of italic paragraph markers
+plaintext_level5_p = (
+    Suppress("(")
+    + Word(string.digits).setResultsName("plaintext_level5")
+    + Suppress(")"))
 
 upper_dec = "." + Word(string.ascii_uppercase).setResultsName('level3')
 roman_dec = "." + Word("ivxlcdm").setResultsName('level2')
@@ -75,7 +81,7 @@ interpretation_marker = (
 )
 
 #   Minimally composed
-depth4_p = upper_p + Optional(em_digit_p)
+depth4_p = upper_p + Optional(em_digit_p) + Optional(plaintext_level5_p)
 depth3_p = roman_p + Optional(depth4_p)
 depth2_p = digit_p + Optional(depth3_p)
 depth1_p = lower_p + Optional(depth2_p)

--- a/tests/tree_reg_text_tests.py
+++ b/tests/tree_reg_text_tests.py
@@ -205,6 +205,23 @@ class DepthRegTextTest(TestCase):
         self.assertEqual(line1, tree.title)
         self.assertEqual(0, len(tree.children))
 
+    def test_build_section_tree_italics_as_plaintext(self):
+        line1 = u"§ 201.20 Super Awesome Section"
+        line2 = "\n(a)(1)(i) paragraphs (c)(2)(ii)(A)(1) and (B) content"
+
+        tree = build_section_tree(line1+line2, 201)
+        self.assertEqual(1, len(tree.children))
+        self.assertEqual(['201', '20'], tree.label)
+        tree = tree.children[0]
+        self.assertEqual(1, len(tree.children))
+        self.assertEqual(['201', '20', 'a'], tree.label)
+        tree = tree.children[0]
+        self.assertEqual(1, len(tree.children))
+        self.assertEqual(['201', '20', 'a', '1'], tree.label)
+        tree = tree.children[0]
+        self.assertEqual(0, len(tree.children))
+        self.assertEqual(['201', '20', 'a', '1', 'i'], tree.label)
+
     def test_build_subparts_tree_reserver(self):
         text = u"Subpart C—[Reserved]"
 


### PR DESCRIPTION
Plain text versions of the regs don't have italics, but do make some references to regulation paragraphs which would need them. This change allows the internal citations grammar to recognize their existence so that the depth-parsing code knows not to break paragraphs within these citations.

See the associated test for an example.
