### PR TITLE
Add statutory name and reg letter to meta data

### DIFF
--- a/regparser/layer/meta.py
+++ b/regparser/layer/meta.py
@@ -1,3 +1,5 @@
+import re
+
 from layer import Layer
 import settings
 
@@ -21,6 +23,15 @@ class Meta(Layer):
             'cfr_title_number': self.cfr_title,
             'cfr_title_text': settings.CFR_TITLES[self.cfr_title]
         }
+
+        if node.title:
+            # up till the paren
+            match = re.search('part \d+[^\w]*([^\(]*)', node.title, re.I)
+            if match:
+                layer['statutory_name'] = match.group(1).strip()
+            match = re.search('\(regulation (\w+)\)', node.title, re.I)
+            if match:
+                layer['reg_letter'] = match.group(1)
 
         last_notice = filter(lambda n: n['document_number'] == self.version,
                              self.notices)

--- a/tests/layer_meta_tests.py
+++ b/tests/layer_meta_tests.py
@@ -1,3 +1,4 @@
+#vim: set encoding=utf-8
 from unittest import TestCase
 
 from regparser.layer.meta import Meta
@@ -67,3 +68,14 @@ class LayerMetaTest(TestCase):
         m = Meta(None, 19, [], None)
         result = m.process(Node(label=['111', '22']))
         self.assertEqual(None, result)
+
+    def test_process_statutory_letter(self):
+        m = Meta(None, 19, [], None)
+        result = m.process(Node(label=['1111']))
+        self.assertFalse('statutory_name' in result[0])
+        self.assertFalse('reg_letter' in result[0])
+
+        result = m.process(Node(label=['1111'],
+                           title=u"PART 1111—RAGGEDY REG (REGULATION R)"))
+        self.assertEqual('RAGGEDY REG', result[0]['statutory_name'])
+        self.assertEqual('R', result[0]['reg_letter'])


### PR DESCRIPTION
We've been calculating this in -site; makes sense to just parse it in -parser.
