### PR TITLE
Remove subpart setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,12 +112,7 @@ written. Only useful if the JSON files are to be written to disk.
 * ```API_BASE``` - a string defining the url root of an API (if the output
 files are to be written to an API instead)
 * ```META``` - a dictionary of extra info which will be included in the
-"meta" layer. Useful fields include "contact_info" (an html string),
-"effective" (a dictionary with "url":string, "title":string,
-"date":date-string), and "last_notice" (a dictionary with "url":string,
-"title":string, "action":string, "published":date-string,
-"effective":date-string)
-* ```SUBPART_STARTS``` - a dictionary describing when subparts begin. See
+"meta" layer. 
 ```settings.py``` for an example.
 * ```CFR_TITLE``` - array of CFR Title names (used in the meta layer)
 * ```DEFAULT_IMAGE_URL``` - string format used in the graphics layer

--- a/regparser/layer/terms.py
+++ b/regparser/layer/terms.py
@@ -40,20 +40,20 @@ class Terms(Layer):
     def add_subparts(self):
         """Document the relationship between sections and subparts"""
 
-        self.current_subpart = None     # Need a reference for the closure
+        current_subpart = [None]    # Need a reference for the closure
 
         def per_node(node):
+            if node.node_type == struct.Node.SUBPART:
+                current_subpart[0] = node.label[2]
+            elif node.node_type == struct.Node.EMPTYPART:
+                current_subpart[0] = None
             if (len(node.label) == 2 and
                 node.node_type in (struct.Node.REGTEXT, struct.Node.APPENDIX)):
                 #Subparts
                 section = node.label[-1]
-                if section in settings.SUBPART_STARTS:
-                    self.current_subpart = settings.SUBPART_STARTS[section]
-                self.subpart_map[self.current_subpart].append(section)
+                self.subpart_map[current_subpart[0]].append(section)
 
         struct.walk(self.tree, per_node)
-
-        del self.current_subpart    # can now remove it
 
     def pre_process(self):
         """Step through every node in the tree, finding definitions. Add

--- a/settings.py
+++ b/settings.py
@@ -1,10 +1,6 @@
 OUTPUT_DIR = ''
 API_BASE = ''
 META = {}
-#   Example usage: {'1': 'A', '8': 'B', 'Interpretations': None} leads to
-#   sections 1:8 in subpart A, 8:Interpretations in subpart B, and
-#   Interpretations: without a subpart
-SUBPART_STARTS = {}
 
 #   All current, US CFR titles
 CFR_TITLES = [

--- a/tests/layer_terms_tests.py
+++ b/tests/layer_terms_tests.py
@@ -7,13 +7,10 @@ from unittest import TestCase
 class LayerTermTest(TestCase):
 
     def setUp(self):
-        self.original_subpart = settings.SUBPART_STARTS
-        settings.SUBPART_STARTS = {'1': None}
         self.original_ignores = settings.IGNORE_DEFINITIONS_IN
         settings.IGNORE_DEFINITIONS_IN = []
 
     def tearDown(self):
-        settings.SUBPART_STARTS = self.original_subpart
         settings.IGNORE_DEFINITIONS_IN = self.original_ignores
 
     def test_has_definitions(self):
@@ -161,7 +158,6 @@ class LayerTermTest(TestCase):
             t.definitions_scopes(node))
 
     def test_pre_process(self):
-        settings.SUBPART_STARTS = {'2': 'XQXQ'}
         noname_subpart = Node('', label=['88', 'Subpart'],
             node_type=Node.EMPTYPART, children=[
                 Node(u"Definition. For the purposes of this part, "


### PR DESCRIPTION
Instead, we build the definition scope based on subparts within the regulation tree
