### PR TITLE
Diffs in Images and Whitespace

### DIFF
--- a/tests/diff_treediff.py
+++ b/tests/diff_treediff.py
@@ -39,15 +39,15 @@ class TreeDiffTest(TestCase):
         codes = treediff.get_opcodes(old, new)
         self.assertEquals(
             [
-                [('delete', 0, 2), ('insert', 0, 'We')],
-                ('insert', 25, 'now')], codes)
+                [('delete', 0, 1), ('insert', 0, 'We')],
+                ('insert', 25, ' now')], codes)
 
     def test_ins_opcodes(self):
         old = "I a string to change"
         new = "I have a string to change"
         codes = treediff.get_opcodes(old, new)
         self.assertEquals(
-            [('insert', 1, 'have')], codes)
+            [('insert', 2, 'have ')], codes)
 
     def test_del_opcodes(self):
         old = "I have a string to change"
@@ -61,7 +61,7 @@ class TreeDiffTest(TestCase):
         new = 'I have a change'
         codes = treediff.get_opcodes(old, new)
         self.assertEquals(
-            [('delete', 8, 18)], codes)
+            [('delete', 9, 19)], codes)
 
     def test_convert_insert(self):
         old = ['gg']
@@ -112,8 +112,11 @@ class TreeDiffTest(TestCase):
         words = treediff.deconstruct_text("Single-word")
         self.assertEqual(['Single-word'], words)
         words = treediff.deconstruct_text("This is a sentence.")
-        self.assertEqual(['This', 'is', 'a', 'sentence.'], words)
+        self.assertEqual(['This', ' ', 'is', ' ', 'a', ' ', 'sentence.'], words)
         words = treediff.deconstruct_text("An image: "
                                           + "![Appendix A9](ER27DE11.000)")
-        self.assertEqual(['An', 'image:', '![Appendix A9](ER27DE11.000)'],
-                         words)
+        self.assertEqual(['An', ' ', 'image:', ' ',
+                          '![Appendix A9](ER27DE11.000)'], words)
+        words = treediff.deconstruct_text("This\nis\t\ta test\n\tpattern")
+        self.assertEqual(['This', '\n', 'is', '\t\t', 'a', ' ', 'test', '\n\t',
+            'pattern'], words)


### PR DESCRIPTION
- Make image tags a 'word'
- Make whitespace characters words

The former allows an image to change without mangling it on the front end. The latter allows us to use different types of whitespace characters; before 'words' would include things like 'end.\n\nNew', which caused strange edits.

Also fixed some tests which had off-by-one errors. These errors cascading into the front-end (see https://github.com/eregs/regulations-site/pull/383)
