### PR TITLE
TOC should list subparts by title unless it's an empty subpart

### DIFF
--- a/regparser/layer/table_of_contents.py
+++ b/regparser/layer/table_of_contents.py
@@ -4,17 +4,13 @@ from regparser.tree.struct import Node
 
 
 class TableOfContentsLayer(Layer):
-
-    def node_is_subpart(self, n):
-        return n.node_type == Node.SUBPART or n.node_type == Node.EMPTYPART
-
     def check_toc_candidacy(self, node):
         """ To be eligible to contain a table of contents, all of a node's
-        children must have a title element. If one of the children is a
-        subpart, we check all it's children.  """
+        children must have a title element. If one of the children is an
+        empty subpart, we check all it's children.  """
 
         for c in node.children:
-            if self.node_is_subpart(c):
+            if c.node_type == Node.EMPTYPART:
                 for s in c.children:
                     if not s.title:
                         return False
@@ -29,7 +25,7 @@ class TableOfContentsLayer(Layer):
         if self.check_toc_candidacy(node):
             layer_element = []
             for c in node.children:
-                if self.node_is_subpart(c):
+                if c.node_type == Node.EMPTYPART:
                     for s in c.children:
                         layer_element.append(
                             {'index': s.label, 'title': s.title})

--- a/tests/table_of_contents.py
+++ b/tests/table_of_contents.py
@@ -48,17 +48,44 @@ class TocTest(TestCase):
         c3 = Node(label=['205', '4'], title='Coverage')
 
         s1 = Node(children=[c1, c2, c3],
-            label=['205', 'Subpart', 'A'], title='First Subpart', node_type=Node.SUBPART)
+                  label=['205', 'Subpart', 'A'], title='First Subpart',
+                  node_type=Node.SUBPART)
 
         c4 = Node(label=['205', '5'], title='Fifth Title')
         s2 = Node(children=[c4],
-            label=['205', 'Subpart', 'B'], title='Second Subpart', node_type=Node.SUBPART)
+                  label=['205', 'Subpart', 'B'], title='Second Subpart',
+                  node_type=Node.SUBPART)
 
         n = Node(children=[s1, s2], label=['205'])
         parser = table_of_contents.TableOfContentsLayer(None)
         toc = parser.process(n)
-        self.assertEquals(len(toc), 4)
-        self.assertEquals(toc[0]['index'], ['205', '2'])
-        self.assertEquals(toc[1]['index'], ['205', '3'])
-        self.assertEquals(toc[2]['index'], ['205', '4'])
-        self.assertEquals(toc[3]['index'], ['205', '5'])
+        self.assertEqual(len(toc), 2)
+        self.assertEqual(toc[0]['index'], ['205', 'Subpart', 'A'])
+        self.assertEqual(toc[1]['index'], ['205', 'Subpart', 'B'])
+
+        toc = parser.process(s1)
+        self.assertEqual(len(toc), 3)
+        self.assertEqual(toc[0]['index'], ['205', '2'])
+        self.assertEqual(toc[1]['index'], ['205', '3'])
+        self.assertEqual(toc[2]['index'], ['205', '4'])
+
+        toc = parser.process(s2)
+        self.assertEqual(len(toc), 1)
+        self.assertEqual(toc[0]['index'], ['205', '5'])
+
+    def test_toc_with_emptysubpart(self):
+        p1 = Node(label=['205', '2'], title='Authority and Purpose')
+        p2 = Node(label=['205', '3'], title='Definitions')
+        p3 = Node(label=['205', '4'], title='Coverage')
+
+        s1 = Node(children=[p1, p2, p3],
+                  label=['205', 'Subpart'],
+                  node_type=Node.EMPTYPART)
+
+        a1 = Node(label=['205', 'A'], title='Appendix A')
+        interp = Node(label=['205', 'Interp'], title='Supplement I')
+        n = Node(children=[s1, a1, interp], label=['205'])
+
+        parser = table_of_contents.TableOfContentsLayer(None)
+        toc = parser.process(n)
+        self.assertEqual(len(toc), 5)


### PR DESCRIPTION
This allows the subpart titles to be discovered in -site
