### PR TITLE
Fix bug with collapsed xml paragraph tags

### DIFF
--- a/regparser/tree/xml_parser/reg_text.py
+++ b/regparser/tree/xml_parser/reg_text.py
@@ -130,7 +130,9 @@ def get_markers_and_text(node, markers_list):
 
     if len(markers_list) > 1:
         actual_markers = ['(%s)' % m for m in markers_list]
-        node_texts = tree_utils.split_text(node_text, actual_markers)
+        plain_markers = [m.replace('<E T="03">', '').replace('</E>', '')
+                         for m in actual_markers]
+        node_texts = tree_utils.split_text(node_text, plain_markers)
         tagged_texts = tree_utils.split_text(text_with_tags, actual_markers)
         node_text_list = zip(node_texts, tagged_texts)
     elif markers_list:

--- a/tests/tree_xml_parser_reg_text_tests.py
+++ b/tests/tree_xml_parser_reg_text_tests.py
@@ -48,6 +48,23 @@ class RegTextTest(TestCase):
 
         self.assertEqual(1, len(node.children[1].children))
 
+    def test_build_section_collapsed_level_emph(self):
+        xml = u"""
+            <SECTION>
+                <SECTNO>§ 8675.309</SECTNO>
+                <SUBJECT>Definitions.</SUBJECT>
+                <P>(a) aaaa</P>
+                <P>(1) 1111</P>
+                <P>(i) iiii</P>
+                <P>(A) AAA—(<E T="03">1</E>) eeee</P>
+            </SECTION>
+        """
+        node = build_section('8675', etree.fromstring(xml))
+        a1iA = node.children[0].children[0].children[0].children[0]
+        self.assertEqual(u"(A) AAA—", a1iA.text)
+        self.assertEqual(1, len(a1iA.children))
+        self.assertEqual("(1) eeee", a1iA.children[0].text.strip())
+
     def test_build_section_reserved(self):
         xml = u"""
             <SECTION>
@@ -236,3 +253,14 @@ class RegTextTest(TestCase):
         self.assertEqual(
             tagged,
             [u'(a) <E T="03">Transfer </E>—', u'(1) <E T="03">Notice.</E> follow'])
+
+    def test_get_markers_and_text_emph(self):
+        text = '(A) aaaa. (<E T="03">1</E>) 1111'
+        xml = etree.fromstring('<P>%s</P>' % text)
+        markers = get_markers(text)
+        result = get_markers_and_text(xml, markers)
+
+        a, a1 = result
+        self.assertEqual(('A', ('(A) aaaa. ', '(A) aaaa. ')), a)
+        self.assertEqual(('<E T="03">1</E>', ('(1) 1111', 
+                                              '(<E T="03">1</E>) 1111')), a1)


### PR DESCRIPTION
> (A) Some content. (_1_) Some more

Was resulting in two paragraphs, with the second containing no text and the first containing everything. This is because we were looking for the markers (to split the text) using the plain text.
