### PR TITLE
XML-based graphics inserted during appendix parse time

### DIFF
--- a/regparser/layer/graphics.py
+++ b/regparser/layer/graphics.py
@@ -6,7 +6,7 @@ import settings
 
 
 class Graphics(Layer):
-    gid = re.compile(ur'!\[([\w\s]+?)\]\(([a-zA-Z0-9.]+?)\)')
+    gid = re.compile(ur'!\[([\w\s]*)\]\(([a-zA-Z0-9.]+?)\)')
 
     def process(self, node):
         """If this node has a marker for an image in it, note where to get

--- a/regparser/tree/xml_parser/appendices.py
+++ b/regparser/tree/xml_parser/appendices.py
@@ -211,6 +211,12 @@ def process_appendix(appendix, part):
             text = tree_utils.get_node_text(child)
             n = Node(text, node_type=Node.APPENDIX, label=['p' + str(counter)])
             tree_utils.add_to_stack(m_stack, depth, n)
+        elif child.tag == 'GPH':
+            counter += 1
+            gid = child.xpath('./GID')[0].text
+            text = '![](' + gid + ')'
+            n = Node(text, node_type=Node.APPENDIX, label=['p' + str(counter)])
+            tree_utils.add_to_stack(m_stack, depth, n)
 
     while m_stack.size() > 1:
         tree_utils.unwind_stack(m_stack)

--- a/tests/layer_graphics_tests.py
+++ b/tests/layer_graphics_tests.py
@@ -16,11 +16,12 @@ class LayerGraphicsTest(TestCase):
 
     def test_process(self):
         node = Node("Testing ![ex](ABCD) then some more XXX " +
-            "some more ![222](XXX) followed by ![ex](ABCD) and XXX")
+            "some more ![222](XXX) followed by ![ex](ABCD) and XXX " +
+            "and ![](NOTEXT)")
         g = Graphics(None)
         result = g.process(node)
-        self.assertEqual(2, len(result))
-        found = [False, False]
+        self.assertEqual(3, len(result))
+        found = [False, False, False]
         for res in result:
             if (res['text'] == '![ex](ABCD)'
                 and 'ABCD' in res['url']
@@ -32,7 +33,13 @@ class LayerGraphicsTest(TestCase):
                 and res['alt'] == '222'
                 and res['locations'] == [0]):
                 found[1] = True
-        self.assertEqual([True, True], found)
+            elif (res['text'] == '![](NOTEXT)'
+                and 'NOTEXT' in res['url']
+                and res['alt'] == ''
+                and res['locations'] == [0]):
+                found[2] = True
+
+        self.assertEqual([True, True, True], found)
 
     def test_process_format(self):
         node = Node("![A88 Something](ER22MY13.257)")

--- a/tests/tree_xml_parser_appendices_tests.py
+++ b/tests/tree_xml_parser_appendices_tests.py
@@ -119,6 +119,10 @@ class AppendicesTest(TestCase):
             <P>Subheader content</P>
             <HD SOURCE="HD1">Header <E T="03">2</E></HD>
             <P>Final <E T="03">Content</E></P>
+            <GPH>
+                <PRTPAGE P="650" />
+                <GID>MYGID</GID>
+            </GPH>
         </APPENDIX>
         """
         appendix = appendices.process_appendix(etree.fromstring(xml), 1111)
@@ -140,9 +144,10 @@ class AppendicesTest(TestCase):
         self.assertEqual('Subheader', sub.title)
         self.assertEqual('Subheader content', sub.children[0].text.strip())
 
-        self.assertEqual(1, len(h2.children))
+        self.assertEqual(2, len(h2.children))
         self.assertEqual('Header 2', h2.title)
         self.assertEqual('Final Content', h2.children[0].text.strip())
+        self.assertEqual('![](MYGID)', h2.children[1].text.strip())
 
     def test_process_inner_child(self):
         xml = """


### PR DESCRIPTION
Simply adds the markdown-style image when compiling the json tree.
