### PR TITLE
bug fixing and expansion of defined term parsing

### DIFF
--- a/regparser/grammar/terms.py
+++ b/regparser/grammar/terms.py
@@ -12,7 +12,9 @@ smart_quotes = (
 
 e_tag = (
     Suppress(Regex(r"<E[^>]*>"))
-    + OneOrMore(Word(srange("[a-zA-Z-]")))
+    + OneOrMore(
+        Word(srange("[a-zA-Z-]"))
+    ).setParseAction(keep_pos).setResultsName("term")
     + Suppress(
         Literal("</E>") + Literal("means")
     )
@@ -20,7 +22,7 @@ e_tag = (
 
 beginning_of_paragraph = (
     Suppress(any_depth_p)
-    + (e_tag).setParseAction(keep_pos).setResultsName("term")
+    + e_tag
 )
 
 term_parser = (

--- a/regparser/layer/terms.py
+++ b/regparser/layer/terms.py
@@ -132,7 +132,8 @@ class Terms(Layer):
                     dropped in preference of new values based on
                     n.text."""
                     pos_start = n.text.find(match.term.tokens[0])
-                    term = ' '.join(match.term.tokens).lower()
+                    term = n.tagged_text[
+                        match.term.pos[0]:match.term.pos[1]].lower()
                     match_len = len(term)
                     add_match(n,
                               term,

--- a/tests/layer_terms_tests.py
+++ b/tests/layer_terms_tests.py
@@ -80,17 +80,21 @@ class LayerTermTest(TestCase):
         xml_text4d = u'(d) <E T="03">Term1</E> or <E T="03">term2></E> means stuff'
         text4e = u'(e) Well-meaning lawyers means people who do weird things'
         xml_text4e = u'(e) <E T="03">Well-meaning lawyers</E> means people who do weird things'
+        text4f = u'(f) Huge billowy clouds means I want to take a nap'
+        xml_text4f = u'(f) <E T="03">Huge billowy clouds</E> means I want to take a nap'
 
         node4a = Node(text4a, label=['eee'])
         node4b = Node(text4b, label=['fff'])
         node4c = Node(text4c, label=['ggg'])
         node4d = Node(text4d, label=['hhh'])
         node4e = Node(text4e, label=['iii'])
+        node4f = Node(text4f, label=['jjj'])
         node4a.tagged_text = xml_text4a
         node4b.tagged_text = xml_text4b
         node4c.tagged_text = xml_text4c
         node4d.tagged_text = xml_text4d
         node4e.tagged_text = xml_text4e
+        node4f.tagged_text = xml_text4f
 
         tree = Node(children=[ 
             Node(text1, label=['aaa']),
@@ -108,11 +112,12 @@ class LayerTermTest(TestCase):
                 node4b,
                 node4c,
                 node4d,
-                node4e
+                node4e,
+                node4f
             ])
         ])
         defs, excluded = t.node_definitions(tree)
-        self.assertEqual(7, len(defs))
+        self.assertEqual(8, len(defs))
         self.assertTrue(Ref('word', 'aaa', (12,16)) in defs)
         self.assertTrue(Ref('another word', 'bbb', (8,20)) in defs)
         self.assertTrue(Ref('moree', 'bbb', (32,37)) in defs)
@@ -120,6 +125,7 @@ class LayerTermTest(TestCase):
         self.assertTrue(Ref('subchildren', 'ddd', (7,18)) in defs)
         self.assertTrue(Ref('thing', 'fff', (4,9)) in defs)
         self.assertTrue(Ref('well-meaning lawyers', 'iii', (4,24)) in defs)
+        self.assertTrue(Ref('huge billowy clouds', 'jjj', (4,23)) in defs)
 
     def test_node_defintions_act(self):
         t = Terms(None)


### PR DESCRIPTION
https://github.com/cfpb/regulations-parser/pull/155 introduced a bug that caught this as a defined term: `"billing cycle</e> or <e t="03">cycle"`

It was happening because I was using `SkipTo()` to match to `"</E> means"`. When there are two terms defined in a row, like "billing cycle or cycle means...", it would capture the last `</E>`.

Instead of using `SkipTo()`, `xml_term_parser` now matches one or more words which can contain dashes.
