### PR TITLE
Do not allow keyterms to also be definitions

### DIFF
--- a/regparser/layer/key_terms.py
+++ b/regparser/layer/key_terms.py
@@ -1,5 +1,6 @@
 from layer import Layer
 from regparser.layer.paragraph_markers import ParagraphMarkers
+from regparser.layer.terms import Terms
 import re
 
 
@@ -29,7 +30,11 @@ class KeyTerms(Layer):
         pattern = re.compile(ur'.*?<E T="03">([^<]*?)</E>.*?', re.UNICODE)
         matches = pattern.match(node.tagged_text)
         if matches and KeyTerms.keyterm_is_first(node, matches.groups()[0]):
-            return matches.groups()[0]
+            included, excluded = Terms(None).node_definitions(node)
+            terms = included + excluded
+            keyterm_as_term = matches.groups()[0].lower()
+            if not any(ref.term == keyterm_as_term for ref in terms):
+                return matches.groups()[0]
 
     def process(self, node):
         """ Get keyterms if we have text in the node that preserves the

--- a/regparser/layer/terms.py
+++ b/regparser/layer/terms.py
@@ -182,7 +182,7 @@ class Terms(Layer):
                 return True
         return False
 
-    def node_definitions(self, node, stack):
+    def node_definitions(self, node, stack=None):
         """Find defined terms in this node's text. 'Act' is a special case,
         as it is also defined as an external citation."""
         included_defs = []
@@ -195,7 +195,7 @@ class Terms(Layer):
             else:
                 included_defs.append(Ref(term, n.label_id(), pos))
 
-        if self.has_parent_definitions_indicator(stack):
+        if stack and self.has_parent_definitions_indicator(stack):
             for match, _, _ in grammar.smart_quotes.scanString(node.text):
                 term = match.term.tokens[0].lower().strip(',.;')
                 #   Don't use pos_end because we are stripping some chars

--- a/tests/layer_keyterms_tests.py
+++ b/tests/layer_keyterms_tests.py
@@ -19,6 +19,23 @@ class LayerKeyTermTest(TestCase):
         self.assertEqual(results[0]['key_term'], 'Apples.')
         self.assertEqual(results[0]['locations'], [0])
 
+    def test_keyterm_definition(self):
+        node = Node("(a) Terminator means I'll be back",
+                    label=['101', '22', 'a'])
+        node.tagged_text = """(a) <E T="03">Terminator</E> means I'll be """
+        node.tagged_text += 'back'
+        kt = KeyTerms(None)
+        results = kt.process(node)
+        self.assertEqual(results, None)
+
+        node = Node("(1) Act means pretend", label=['101', '22', 'a', '1'])
+        node.tagged_text = """(1) <E T="03">Act</E> means pretend"""
+        node = Node("(1) Act means the Truth in Lending Act (15 U.S.C. 1601 et seq.).", label=['1026', '2', 'a', '1'])
+        node.tagged_text = """(1) <E T="03">Act</E> means the Truth in Lending Act (15 U.S.C. 1601 <E T="03">et seq.</E>)."""
+        kt = KeyTerms(None)
+        results = kt.process(node)
+        self.assertEqual(results, None)
+
     def test_emphasis_later(self):
         """ Don't pick up something that is emphasized later in a paragraph as
         a key-term. """


### PR DESCRIPTION
Adds a check when calculating the keyterm layer: is this a definition? If so, don't add a keyterm.
