### PR TITLE
Skip over STARS when determining the next regtext marker

### DIFF
--- a/regparser/tree/xml_parser/reg_text.py
+++ b/regparser/tree/xml_parser/reg_text.py
@@ -179,7 +179,7 @@ def next_marker(xml_node, remaining_markers):
 
     #   Check the next xml node; skip over stars
     sib = xml_node.getnext()
-    if sib is not None and sib.tag == 'STARS':
+    while sib is not None and sib.tag == 'STARS':
         sib = sib.getnext()
     if sib is not None:
         next_text = tree_utils.get_node_text(sib)

--- a/tests/tree_xml_parser_reg_text_tests.py
+++ b/tests/tree_xml_parser_reg_text_tests.py
@@ -355,6 +355,7 @@ class RegTextTest(TestCase):
             <ROOT>
                 <P>(i) Content</P>
                 <STARS />
+                <STARS />
                 <P>(xi) More</P>
             </ROOT>""")
         self.assertEqual('xi', next_marker(xml.getchildren()[0], []))


### PR DESCRIPTION
Small commit that will help with partial regtext parsing
