### PR TITLE
Skip over intro paragraphs in the SxS

### DIFF
--- a/regparser/notice/sxs.py
+++ b/regparser/notice/sxs.py
@@ -1,12 +1,11 @@
 from copy import deepcopy
-from itertools import chain, dropwhile, takewhile
+from itertools import dropwhile, takewhile
 
 from lxml import etree
 
 from regparser.citations import internal_citations, Label
 from regparser.notice.util import body_to_string, spaces_then_remove
 from regparser.notice.util import swap_emphasis_tags
-from regparser.tree.struct import Node
 
 
 def find_section_by_section(xml_tree):
@@ -18,10 +17,12 @@ def find_section_by_section(xml_tree):
         or 'section-by-section' not in el.text.lower()), xml_children)
 
     try:
-        #Ignore Header
+        # Ignore Header
         sxs.next()
+        # Remove any intro paragraphs
+        sxs = dropwhile(lambda el: el.tag != 'HD', sxs)
         sxs = takewhile(
-            lambda e: e.tag != 'HD' or e.get('SOURCE') != 'HD1', sxs)
+            lambda el: el.tag != 'HD' or el.get('SOURCE') != 'HD1', sxs)
 
         return list(sxs)
     except StopIteration:

--- a/tests/notice_sxs_tests.py
+++ b/tests/notice_sxs_tests.py
@@ -50,6 +50,29 @@ class NoticeSxsTests(TestCase):
         computed = find_section_by_section(etree.fromstring(full_xml))
         self.assertEqual(sxs_texts, map(lambda el: el.text, computed))
 
+    def test_find_section_by_section_intro_text(self):
+        sxs_xml = """
+            <P>Some intro text</P>
+            <P>This text includes a reference to Section 8675.309(a)</P>
+            <HD SOURCE="HD2">Section 8675.309 Stuff</HD>
+            <P>Content</P>"""
+        full_xml = """
+        <ROOT>
+            <SUPLINF>
+                <HD SOURCE="HED">Supplementary Info</HD>
+                <HD SOURCE="HD1">Stuff Here</HD>
+                <P>Some Content</P>
+                <HD SOURCE="HD1">X. Section-by-Section Analysis</HD>
+                %s
+                <HD SOURCE="HD1">Section that follows</HD>
+                <P>Following Content</P>
+            </SUPLINF>
+        </ROOT>""" % sxs_xml
+
+        sxs_texts = ['Section 8675.309 Stuff', 'Content']
+        computed = find_section_by_section(etree.fromstring(full_xml))
+        self.assertEqual(sxs_texts, map(lambda el: el.text, computed))
+
     def test_find_section_by_section_not_present(self):
         full_xml = """
         <ROOT>


### PR DESCRIPTION
The parser assumes the first thing it's reading is a header. Not all SxS sections start this way, though, which proved to be a particular problem when those intro paragraphs included citations. The parser treated the paragraphs as a header, found their labels, and duplicated their children (once per citation.)

Since intro paragraphs are at the begininning, this causes the SxS structure to be gigantic.
