### PR TITLE
Parse notes in appendices

### DIFF
--- a/regparser/tree/xml_parser/appendices.py
+++ b/regparser/tree/xml_parser/appendices.py
@@ -284,6 +284,20 @@ class AppendixProcessor(object):
         self._indent_if_needed()
         self.m_stack.add(self.depth, n)
 
+    def note(self, xml_node):
+        """Use github-like fencing to indicate this is a note"""
+        self.paragraph_counter += 1
+        texts = ["```note"]
+        for child in xml_node:
+            texts.append(tree_utils.get_node_text(child).strip())
+        texts.append("```")
+        n = Node("\n".join(texts), node_type=Node.APPENDIX,
+                 label=['p' + str(self.paragraph_counter)],
+                 source_xml=xml_node)
+
+        self._indent_if_needed()
+        self.m_stack.add(self.depth, n)
+
     def process(self, appendix, part):
         self.m_stack = tree_utils.NodeStack()
 
@@ -323,6 +337,8 @@ class AppendixProcessor(object):
                 self.graphic(child)
             elif child.tag == 'GPOTABLE':
                 self.table(child)
+            elif child.tag in ('NOTE', 'NOTES'):
+                self.note(child)
 
         while self.m_stack.size() > 1:
             self.m_stack.unwind()

--- a/tests/layer_formatting_tests.py
+++ b/tests/layer_formatting_tests.py
@@ -95,3 +95,12 @@ class LayerFormattingTests(TestCase):
             [['11', '12', '13', '14'],
              ['21', '22', '23'],
              ['', '32', '33', '34']])
+
+    def test_process_fenced(self):
+        node = Node("Content content\n```abc def\nLine 1\nLine 2\n```")
+        result = formatting.Formatting(None).process(node)
+        self.assertEqual(1, len(result))
+        result = result[0]
+        self.assertEqual(result['text'], node.text[16:])
+        self.assertEqual(result['fence_data'],
+                         {'type': 'abc def', 'lines': ['Line 1', 'Line 2']})

--- a/tests/tree_xml_parser_appendices_tests.py
+++ b/tests/tree_xml_parser_appendices_tests.py
@@ -225,6 +225,23 @@ class AppendicesTest(TestCase):
         self.assertEqual(['1111', 'A', '2', 'b'], a2b.label)
         self.assertEqual(0, len(a2b.children))
 
+    def test_process_notes(self):
+        xml = u"""
+        <APPENDIX>
+            <HD SOURCE="HED">Appendix A to Part 1111—Awesome</HD>
+            <NOTE>
+                <P>Par</P>
+                <E>Emem</E>
+                <P>Parparpar</P>
+            </NOTE>
+        </APPENDIX>"""
+        appendix = appendices.process_appendix(etree.fromstring(xml), 1111)
+        self.assertEqual(['1111', 'A'], appendix.label)
+        self.assertEqual(1, len(appendix.children))
+        note = appendix.children[0]
+        text = '```note\nPar\nEmem\nParparpar\n```'
+        self.assertEqual(note.text, text)
+
     def test_initial_marker(self):
         self.assertEqual(("i", "i."), appendices.initial_marker("i. Hi"))
         self.assertEqual(("iv", "iv."), appendices.initial_marker("iv. Hi"))


### PR DESCRIPTION
Converts the NOTE/NOTES tag into a github markdown-style fenced text. This fenced text is then processed by the formatting layer. The result is already rendered in -site.
