### PR TITLE
Account for changes to children only (* * *)

### DIFF
--- a/regparser/layer/key_terms.py
+++ b/regparser/layer/key_terms.py
@@ -1,5 +1,5 @@
 from layer import Layer
-from regparser.layer.paragraph_markers import ParagraphMarkers
+from regparser.layer.paragraph_markers import marker_of
 from regparser.layer.terms import Terms
 import re
 
@@ -7,10 +7,8 @@ import re
 class KeyTerms(Layer):
     @staticmethod
     def process_node_text(node):
-        """ Take a paragraph, remove the marker, and extraneous whitespaces.
-        """
-
-        marker = ParagraphMarkers.marker(node)
+        """Take a paragraph, remove the marker, and extraneous whitespaces."""
+        marker = marker_of(node)
         text = node.tagged_text
 
         text = text.replace(marker, '', 1).strip()

--- a/regparser/layer/paragraph_markers.py
+++ b/regparser/layer/paragraph_markers.py
@@ -2,27 +2,26 @@ from layer import Layer
 from regparser.tree.struct import Node
 
 
-class ParagraphMarkers(Layer):
+def marker_of(node):
+    """Paragraphs have different markers -- regtext has parentheses,
+    interpretations have periods. Appendices, in all of their flexibility,
+    can have either"""
+    m = [l for l in node.label if l != Node.INTERP_MARK][-1]
 
+    if node.node_type == Node.INTERP:
+        return m + '.'
+    elif node.node_type == Node.APPENDIX and node.text.startswith(m + '.'):
+        return m + '.'
+    else:
+        return '(%s)' % m
+
+
+class ParagraphMarkers(Layer):
     def process(self, node):
         """Look for any leading paragraph markers."""
-        marker = ParagraphMarkers.marker(node)
+        marker = marker_of(node)
         if node.text.strip().startswith(marker):
             return [{
                 "text": marker,
                 "locations": [0]
             }]
-
-    @staticmethod
-    def marker(node):
-        """Paragraphs have different markers -- regtext has parentheses,
-        interpretations have periods. Appendices, in all of their flexibility,
-        can have either"""
-        m = [l for l in node.label if l != Node.INTERP_MARK][-1]
-
-        if node.node_type == Node.INTERP:
-            return m + '.'
-        elif node.node_type == Node.APPENDIX and node.text.startswith(m + '.'):
-            return m + '.'
-        else:
-            return '(%s)' % m

--- a/regparser/notice/changes.py
+++ b/regparser/notice/changes.py
@@ -6,9 +6,10 @@ import logging
 import copy
 from collections import defaultdict
 
+from regparser.diff.treediff import node_to_dict
+from regparser.layer.paragraph_markers import marker_of
 from regparser.tree import struct
 from regparser.tree.paragraph import p_levels
-from regparser.diff.treediff import node_to_dict
 
 
 def bad_label(node):
@@ -167,6 +168,14 @@ def create_add_amendment(amendment):
     nodes_list = []
     flatten_tree(nodes_list, amendment['node'])
     nodes = [format_node(n, amendment) for n in nodes_list]
+
+    text = amendment['node'].text.strip()
+    marker = marker_of(amendment['node'])
+    text = text[len(marker):].strip()
+    if text == '* * *':
+        label = amendment['node'].label_id()
+        root_change = [d for d in nodes if label in d][0][label]
+        root_change['field'] = '[children]'
     return nodes
 
 

--- a/regparser/notice/compiler.py
+++ b/regparser/notice/compiler.py
@@ -399,6 +399,14 @@ def one_change(reg, label, change):
         reg.replace_node_and_subtree(node)
     elif change['action'] == 'PUT' and change['field'] in field_list:
         replace_node_field(reg, label, change)
+    elif change['action'] == 'PUT' and change['field'] == '[children]':
+        # A bit counter-intuitive; we're only modifying the children, so we
+        # first delete all existing children; new children will be re-added
+        existing = reg.find_node(label)
+        if existing:
+            existing.children = []
+        else:
+            logging.warning("Attempted to delete children of %s", label)
     elif change['action'] == 'POST':
         node = dict_to_node(change['node'])
         if 'subpart' in change and len(node.label) == 2:

--- a/tests/layer_paragraph_markers_tests.py
+++ b/tests/layer_paragraph_markers_tests.py
@@ -5,7 +5,6 @@ from regparser.tree.struct import Node
 
 
 class ParagraphMarkersTest(TestCase):
-
     def test_process_no_results(self):
         pm = ParagraphMarkers(None)
         self.assertEqual(None, pm.process(

--- a/tests/notice_build_tests.py
+++ b/tests/notice_build_tests.py
@@ -462,6 +462,26 @@ class NoticeBuildTest(TestCase):
         self.assertEqual(reserve['action'], 'RESERVE')
         self.assertEqual(reserve['node']['text'], u'[Reserved]')
 
+    def test_create_changes_stars(self):
+        labels_amended = [Amendment('PUT', '200-2-a')]
+        n2a1 = Node('(1) Content', label=['200', '2', 'a', '1'])
+        n2a2 = Node('(2) Content', label=['200', '2', 'a', '2'])
+        n2a = Node('(a) * * *', label=['200', '2', 'a'], children=[n2a1, n2a2])
+        n2 = Node('n2', label=['200', '2'], children=[n2a])
+        root = Node('root', label=['200'], children=[n2])
+
+        notice_changes = changes.NoticeChanges()
+        build.create_changes(labels_amended, root, notice_changes)
+
+        for label in ('200-2-a', '200-2-a-1', '200-2-a-2'):
+            self.assertTrue(label in notice_changes.changes)
+            self.assertEqual(1, len(notice_changes.changes[label]))
+            change = notice_changes.changes[label][0]
+            self.assertEqual('PUT', change['action'])
+
+        change = notice_changes.changes['200-2-a'][0]
+        self.assertEqual('[children]', change.get('field'))
+
     def test_local_version_list(self):
         url = 'http://example.com/some/url'
 

--- a/tests/notice_compiler_tests.py
+++ b/tests/notice_compiler_tests.py
@@ -477,6 +477,27 @@ class CompilerTests(TestCase):
         changed_node = find(reg, '205-2-a')
         self.assertEqual(changed_node.text, 'new text')
 
+    def test_compile_reg_put_children_only(self):
+        root = self.tree_with_paragraphs()
+        change2 = {'action': 'PUT',
+                   'field': '[children]',
+                   'node': {'text': '* * *', 'label': ['205', '2'],
+                            'node_type': 'regtext'}}
+        change2a = {'action': 'PUT',
+                    'node': {'text': '(a) A Test', 'label': ['205', '2', 'a'],
+                             'node_type': 'regtext'}}
+
+        notice_changes = {'205-2': [change2], '205-2-a': [change2a]}
+        reg = compiler.compile_regulation(root, notice_changes)
+
+        changed = find(reg, '205-2')
+        self.assertEqual(changed.text, 'n2')    # text didn't change
+        self.assertEqual(1, len(changed.children))
+        changed2a = changed.children[0]
+        self.assertEqual(['205', '2', 'a'], changed2a.label)
+        self.assertEqual('(a) A Test', changed2a.text)
+        self.assertEqual([], changed2a.children)
+
     def test_compile_reg_post_no_subpart(self):
         root = self.tree_with_paragraphs()
         change2a1 = {


### PR DESCRIPTION
Adds a "[children]" field for notice changes, which is triggered whenever the body of a node is just "\* \* *". When this field is set, the compiler clears out a node's children (which get added individually due to the flattening process.) Also, did some cleanup with ParagraphMarkers - it is no longer using a static method.
