### PR TITLE
Tweaks to resolve some regressions

### DIFF
--- a/regparser/notice/build.py
+++ b/regparser/notice/build.py
@@ -213,9 +213,11 @@ def preprocess_notice_xml(notice_xml):
     for amdpar in notice_xml.xpath("//AMDPAR"):
         if amdpar.getnext() is None:
             parent = amdpar.getparent()
-            if parent.getnext() is not None:
+            next_parent = parent.getnext()
+            if (next_parent is not None
+                    and parent.get('PART') == next_parent.get('PART')):
                 parent.remove(amdpar)
-                parent.getnext().insert(0, amdpar)
+                next_parent.insert(0, amdpar)
 
     # Supplement I AMDPARs are often incorrect (labelled as Ps)
     xpath_contains_supp = "contains(., 'Supplement I')"
@@ -273,6 +275,8 @@ def process_amendments(notice, notice_xml):
             else:
                 other_labels.append(al)
 
+        create_xmlless_changes(other_labels, notice_changes)
+
         section_xml = find_section(par)
         if section_xml is not None:
             for section in reg_text.build_from_section(
@@ -287,8 +291,6 @@ def process_amendments(notice, notice_xml):
                                       aXp.parent)
         if interp:
             create_xml_changes(other_labels, interp, notice_changes)
-
-        create_xmlless_changes(other_labels, notice_changes)
 
         amends.extend(designate_labels)
         amends.extend(other_labels)

--- a/tests/notice_build_tests.py
+++ b/tests/notice_build_tests.py
@@ -628,6 +628,31 @@ class NoticeBuildTest(TestCase):
         self.assertEqual(amd2a.getparent().xpath(".//P")[0].text.strip(),
                          "(a) Content")
 
+        notice_xml = etree.fromstring(u"""
+            <PART>
+                <REGTEXT PART="105">
+                    <AMDPAR>1. In § 105.1, revise paragraph (b):</AMDPAR>
+                    <SECTION>
+                        <STARS />
+                        <P>(b) Content</P>
+                    </SECTION>
+                    <AMDPAR>
+                        3. In § 105.2, revise paragraph (a) to read as follows:
+                    </AMDPAR>
+                </REGTEXT>
+                <REGTEXT PART="107">
+                    <SECTION>
+                        <P>(a) Content</P>
+                    </SECTION>
+                </REGTEXT>
+            </PART>""")
+        notice_xml = build.preprocess_notice_xml(notice_xml)
+        amd1b, amd2a = notice_xml.xpath("//AMDPAR")
+        self.assertEqual(amd1b.getparent().xpath(".//P")[0].text.strip(),
+                         "(b) Content")
+        self.assertEqual(amd2a.getparent().xpath(".//P")[0].text.strip(),
+                         "(b) Content")
+
     def test_preprocess_notice_xml_interp_amds_are_ps(self):
         notice_xml = etree.fromstring(u"""
             <PART>


### PR DESCRIPTION
In #214, updates that did not need an XML tree were separated from those that do.

Applying this to another reg brought some bugs. In some cases, we rely on order, and we assume the MOVE, etc. operations (XMLless) happen _before_ edits. Instead of figuring out the delay, I've just re-ordered the execution.

Also, fixes an issue where an amendment to a different cfr part got associated with the following cfr part.
