### PR TITLE
Allow appendices and reserved sections to be updated

### DIFF
--- a/regparser/notice/compiler.py
+++ b/regparser/notice/compiler.py
@@ -305,11 +305,6 @@ class RegulationTree(object):
 
     def add_node(self, node):
         """ Add an entirely new node to the regulation tree. """
-
-        if ((node.node_type == Node.APPENDIX and len(node.label) == 2)
-                or node.node_type == Node.SUBPART):
-            return self.add_to_root(node)
-
         existing = find(self.tree, node.label_id())
         if existing and is_reserved_node(existing):
             logging.warning('Replacing reserved node: %s' % node.label_id())
@@ -333,15 +328,20 @@ class RegulationTree(object):
                 print '%s %s' % (existing.text, node.label)
                 print '----'
 
-            parent = self.get_parent(node)
-            if parent is None:
-                # This is a corner case, where we're trying to add a child
-                # to a parent that should exist.
-                logging.warning('No existing parent for: %s' % node.label_id())
-                parent = self.create_empty_node(get_parent_label(node))
-            parent.children = self.add_child(parent.children, node,
-                                             getattr(parent, 'child_labels',
-                                                     []))
+            if ((node.node_type == Node.APPENDIX and len(node.label) == 2)
+                    or node.node_type == Node.SUBPART):
+                return self.add_to_root(node)
+            else:
+                parent = self.get_parent(node)
+                if parent is None:
+                    # This is a corner case, where we're trying to add a child
+                    # to a parent that should exist.
+                    logging.warning('No existing parent for: %s' %
+                                    node.label_id())
+                    parent = self.create_empty_node(get_parent_label(node))
+                parent.children = self.add_child(
+                    parent.children, node, getattr(parent, 'child_labels',
+                                                   []))
 
     def add_section(self, node, subpart_label):
         """ Add a new section to a subpart. """

--- a/tests/notice_compiler_tests.py
+++ b/tests/notice_compiler_tests.py
@@ -271,6 +271,24 @@ class CompilerTests(TestCase):
                          reg_tree.tree.children[0].label)
         self.assertEqual(['205', 'A'], reg_tree.tree.children[1].label)
 
+    def test_add_node_reserved_appendix(self):
+        reserved_node = Node('', label=['205', 'R'], node_type=Node.APPENDIX,
+                             title='Appendix R-[Reserved]')
+        root = Node('', label=['205'], children=[reserved_node])
+        reg_tree = compiler.RegulationTree(root)
+
+        new_node = Node('', label=['205', 'R'], node_type=Node.APPENDIX,
+                        title="Appendix R-Revision'd", children=[
+                            Node('R1', label=['205', 'R', '1'],
+                                 node_type=Node.APPENDIX),
+                            Node('R2', label=['205', 'R', '2'],
+                                 node_type=Node.APPENDIX)])
+        reg_tree.add_node(new_node)
+
+        added_node = find(reg_tree.tree, '205-R')
+        self.assertEqual(2, len(added_node.children))
+        self.assertEqual("Appendix R-Revision'd", added_node.title)
+
     def test_move_interps(self):
         n1 = Node('n1', label=['205', '1', 'Interp'], node_type=Node.INTERP)
         n2 = Node('n2', label=['205', '2', 'Interp'], node_type=Node.INTERP)


### PR DESCRIPTION
We escaped early if we were adding root elements. Now that check occurs deeper in the code, allowing the "are you reserved?" check to happen first.
