### PR TITLE
Account for MOVE then PUT at any point in the list of tokens

### DIFF
--- a/regparser/notice/diff.py
+++ b/regparser/notice/diff.py
@@ -186,16 +186,25 @@ def move_then_modify(tokenized):
     """The subject of modification may be implicit in the preceding move
     operation: A is redesignated B and changed. Replace the operation with a
     DELETE and a POST so it's easier to compile later."""
-    if len(tokenized) == 4:
-        move, p1, p2, edit = tokenized
+    final_tokens = []
+    idx = 0
+    while idx < len(tokenized) - 3:
+        move, p1, p2, edit = tokenized[idx:idx + 4]
         if (move.match(tokens.Verb, verb=tokens.Verb.MOVE, active=True)
                 and p1.match(tokens.Paragraph)
                 and p2.match(tokens.Paragraph)
                 and edit.match(tokens.Verb, verb=tokens.Verb.PUT,
                                active=True, and_prefix=True)):
-            return [tokens.Verb(tokens.Verb.DELETE, active=True), p1,
-                    tokens.Verb(tokens.Verb.POST, active=True), p2]
-    return tokenized
+            final_tokens.append(tokens.Verb(tokens.Verb.DELETE, active=True))
+            final_tokens.append(p1)
+            final_tokens.append(tokens.Verb(tokens.Verb.POST, active=True))
+            final_tokens.append(p2)
+            idx += 4
+        else:
+            final_tokens.append(tokenized[idx])
+            idx += 1
+    final_tokens.extend(tokenized[idx:])
+    return final_tokens
 
 
 def parse_amdpar(par, initial_context):

--- a/tests/notice_diff_tests.py
+++ b/tests/notice_diff_tests.py
@@ -706,6 +706,23 @@ class NoticeDiffTests(TestCase):
         self.assertEqual(amd.label, ['1111', '12', 'c'])
         self.assertEqual(amd.field, '[text]')
 
+    def test_parse_amdpar_moved_then_modified(self):
+        text = "Under Paragraph 22(a), paragraph 1 is revised, paragraph "
+        text += "2 is redesignated as paragraph 3 and revised, and new "
+        text += "paragraph 2 is added."
+        xml = etree.fromstring('<AMDPAR>%s</AMDPAR>' % text)
+        amends, _ = parse_amdpar(xml, ['1111', 'Interpretations'])
+        self.assertEqual(4, len(amends))
+        a1, a2del, a3, a2add = amends
+        self.assertEqual(a1.action, tokens.Verb.PUT)
+        self.assertEqual(a1.label, ['1111', '22', 'a', 'Interp', '1'])
+        self.assertEqual(a2del.action, tokens.Verb.DELETE)
+        self.assertEqual(a2del.label, ['1111', '22', 'a', 'Interp', '2'])
+        self.assertEqual(a3.action, tokens.Verb.POST)
+        self.assertEqual(a3.label, ['1111', '22', 'a', 'Interp', '3'])
+        self.assertEqual(a2add.action, tokens.Verb.POST)
+        self.assertEqual(a2add.label, ['1111', '22', 'a', 'Interp', '2'])
+
 
 class AmendmentTests(TestCase):
     def test_fix_label(self):


### PR DESCRIPTION
Previously, we limited the conversion of MOVE+PUT into DELETE+POST only when that was the only action taken in the list.

This patch moves a window along the token list to check for that pattern anywhere.
