### PR TITLE
Don't resort nodes upon insertion

### DIFF
--- a/tests/notice_compiler_tests.py
+++ b/tests/notice_compiler_tests.py
@@ -69,7 +69,7 @@ class CompilerTests(TestCase):
         reg_tree = compiler.RegulationTree(None)
 
         n3 = Node('n3', label=['205', '3'])
-        reg_tree.add_child(children, n3)
+        children = reg_tree.add_child(children, n3)
 
         self.assertEqual(children, [n1, n2, n3, n4])
         for c in children:
@@ -80,23 +80,23 @@ class CompilerTests(TestCase):
         n2 = Node('M2', label=['205', 'M2'], node_type=Node.APPENDIX)
 
         children = [n2]
-        compiler.RegulationTree(None).add_child(children, n1)
+        children = compiler.RegulationTree(None).add_child(children, n1)
 
         self.assertEqual(children, [n1, n2])
         n3 = Node('M10a', label=['205', 'M(10)(a)'], node_type=Node.APPENDIX)
         n4 = Node('M10b', label=['205', 'M(10)(b)'], node_type=Node.APPENDIX)
 
-        compiler.RegulationTree(None).add_child(children, n4)
+        children = compiler.RegulationTree(None).add_child(children, n4)
         self.assertEqual(children, [n1, n2, n4])
-        compiler.RegulationTree(None).add_child(children, n3)
+        children = compiler.RegulationTree(None).add_child(children, n3)
         self.assertEqual(children, [n1, n2, n3, n4])
 
         n5 = Node('p20', label=['205', 'p20'], node_type=Node.APPENDIX)
         n6 = Node('p3', label=['205', 'p3'], node_type=Node.APPENDIX)
 
-        compiler.RegulationTree(None).add_child(children, n5)
+        children = compiler.RegulationTree(None).add_child(children, n5)
         self.assertEqual(children, [n1, n2, n3, n4, n5])
-        compiler.RegulationTree(None).add_child(children, n6)
+        children = compiler.RegulationTree(None).add_child(children, n6)
         self.assertEqual(children, [n1, n2, n3, n4, n6, n5])
 
     def test_add_child_interp(self):
@@ -107,7 +107,7 @@ class CompilerTests(TestCase):
         n10 = Node('n10', label=['205', '10', 'Interp'])
 
         children = [n1, n5, n10]
-        reg_tree.add_child(children, n9)
+        children = reg_tree.add_child(children, n9)
         self.assertEqual(children, [n1, n5, n9, n10])
 
         n1.label = ['205', '1', 'a', '1', 'i', 'Interp']
@@ -115,7 +115,7 @@ class CompilerTests(TestCase):
         n9.label = ['205', '1', 'a', '1', 'ix', 'Interp']
         n10.label = ['205', '1', 'a', '1', 'x', 'Interp']
         children = [n1, n5, n10]
-        reg_tree.add_child(children, n9)
+        children = reg_tree.add_child(children, n9)
         self.assertEqual(children, [n1, n5, n9, n10])
 
         n1.label = ['205', '1', 'a', 'Interp', '1', 'i']
@@ -123,8 +123,17 @@ class CompilerTests(TestCase):
         n9.label = ['205', '1', 'a', 'Interp', '1', 'ix']
         n10.label = ['205', '1', 'a', 'Interp', '1', 'x']
         children = [n1, n5, n10]
-        reg_tree.add_child(children, n9)
+        children = reg_tree.add_child(children, n9)
         self.assertEqual(children, [n1, n5, n9, n10])
+
+        n1.label = ['205', '1', 'Interp', '1']
+        n5.label = ['205', '1', 'a', 'Interp']
+        children = [n1]
+        children = reg_tree.add_child(children, n5)
+        self.assertEqual(children, [n1, n5])
+        children = [n5]
+        children = reg_tree.add_child(children, n1)
+        self.assertEqual(children, [n1, n5])
 
     def test_add_child_order(self):
         reg_tree = compiler.RegulationTree(None)
@@ -142,7 +151,8 @@ class CompilerTests(TestCase):
         children = reg_tree.add_child(children, n3, order)
         self.assertEqual(children, [n3, n2, n1])
         children = reg_tree.add_child(children, n4, order)
-        self.assertEqual(children, [n1, n2, n3, n4])
+        #   Original order is modified as little as possible
+        self.assertEqual(children, [n3, n2, n1, n4])
 
         children = [n1, n2]
         children = reg_tree.add_child(children, n4, order)


### PR DESCRIPTION
When modifying the node tree, as nodes are added, they must be inserted into their parent's "children" list. Previously, we'd append to the end of that list and then resort.

That strategy works well when the original list is sorted, but causes order errors when the original list was only _mostly_ sorted (as with regulations). This patch uses `bisect` (thanks for the suggestion @khandelwal) to insert "in place". The solution won't work for an arbitrary list, but given our _mostly_ sorted lists, it works well.

In addition, always place interpretation paragraphs before sub-interpretations (e.g. "1234-11-Interp-1" before "1234-11-1-Interp").
