### PR TITLE
Catch another type of citation

### DIFF
--- a/regparser/citations.py
+++ b/regparser/citations.py
@@ -189,6 +189,8 @@ def internal_citations(text, initial_label=None, require_marker=False):
     single_citations(grammar.m_section_paragraph.scanString(text), False)
     if not require_marker:
         single_citations(grammar.section_paragraph.scanString(text), False)
+        single_citations(grammar.part_section_paragraph.scanString(text),
+                         False)
 
     # Some appendix citations are... complex
     for match, start, end in grammar.appendix_with_part.scanString(text):

--- a/regparser/grammar/unified.py
+++ b/regparser/grammar/unified.py
@@ -33,6 +33,11 @@ section_comment = atomic.section + depth1_c
 section_paragraph = atomic.section + depth1_p
 
 mps_paragraph = marker_part_section + Optional(depth1_p)
+part_section_paragraph = (
+    atomic.part + Suppress(".") + atomic.section + depth1_p)
+
+
+part_section + Optional(depth1_p)
 
 m_section_paragraph = (
     atomic.paragraph_marker.copy().setParseAction(

--- a/regparser/notice/sxs.py
+++ b/regparser/notice/sxs.py
@@ -83,7 +83,7 @@ def build_section_by_section(sxs, part, fr_start_page):
         if not labels:
             structures.append(next_structure)
         for label in labels:
-            cp_structure = dict(next_structure) # shallow copy
+            cp_structure = dict(next_structure)  # shallow copy
             cp_structure['label'] = label
             structures.append(cp_structure)
 
@@ -124,8 +124,8 @@ def split_into_ttsr(sxs):
 
 
 def parse_into_labels(txt, part):
-    """Find what part+section+(paragraph) (could be multiple) this text is 
+    """Find what part+section+(paragraph) (could be multiple) this text is
     related to."""
     citations = internal_citations(txt, Label(part=part))
-    labels =  ['-'.join(cit.label.to_list()) for cit in citations]
+    labels = ['-'.join(cit.label.to_list()) for cit in citations]
     return labels

--- a/tests/notice_sxs_tests.py
+++ b/tests/notice_sxs_tests.py
@@ -346,7 +346,8 @@ class NoticeSxsTests(TestCase):
         self.assertEqual(["101-22-d-5-x"],
                          parse_into_labels("22(d)(5)(x) Content", "101"))
         self.assertEqual(["101-22-d-5-x"],
-                         parse_into_labels(u"§ 101.22(d)(5)(x) Content", "101"))
+                         parse_into_labels(u"§ 101.22(d)(5)(x) Content",
+                                           "101"))
         self.assertEqual(["101-22-d-5-x-Q"],
                          parse_into_labels("22(d)(5)(x)(Q) Content", "101"))
         self.assertEqual(["101-A"],
@@ -362,6 +363,9 @@ class NoticeSxsTests(TestCase):
 
         self.assertEqual([],
                          parse_into_labels("Application of this rule", "101"))
+        text = 'Section 1111.39Content content 1111.39(d) Exeptions'
+        self.assertEqual(['1111-39', '1111-39-d'],
+                         parse_into_labels(text, '101'))
 
     def test_is_child_of(self):
         parent = """<HD SOURCE="H2">Section 22.1</HD>"""


### PR DESCRIPTION
Treat "1111.23(a)" (note missing section marker) as a paragraph citation when attempting to parse _any_ citations. This means that such a citation will be triggered in a SxS or interp header, but not an internal citation.
