### PR TITLE
Unfold EXTRACT tags for SxS computation

### DIFF
--- a/regparser/notice/sxs.py
+++ b/regparser/notice/sxs.py
@@ -8,9 +8,24 @@ from regparser.notice.util import body_to_string, spaces_then_remove
 from regparser.notice.util import swap_emphasis_tags
 
 
+def remove_extract(xml_tree):
+    """Occasionally, the paragraphs/etc. useful to us are inside an EXTRACT
+    tag. To normalize, move everything in an EXTRACT tag out"""
+    xml_tree = deepcopy(xml_tree)
+    for extract in xml_tree.xpath('//EXTRACT'):
+        parent = extract.getparent()
+        insert_idx = parent.index(extract)
+        for child in extract:
+            extract.remove(child)
+            parent.insert(insert_idx, child)
+            insert_idx += 1
+        parent.remove(extract)
+    return xml_tree
+
+
 def find_section_by_section(xml_tree):
     """Find the section-by-section analysis of this notice"""
-    xml_children = xml_tree.xpath('//SUPLINF/*')
+    xml_children = remove_extract(xml_tree).xpath('//SUPLINF/*')
     sxs = dropwhile(lambda el: (
         el.tag != 'HD'
         or el.get('SOURCE') != 'HD1'

--- a/tests/notice_sxs_tests.py
+++ b/tests/notice_sxs_tests.py
@@ -29,6 +29,7 @@ class NoticeSxsTests(TestCase):
             <HD SOURCE="HD2">Sub Section</HD>
             <P>Content</P>
             <HD SOURCE="HD3">Sub sub section</HD>
+            <EXTRACT><P>This is in an extract</P></EXTRACT>
             <P>Sub Sub Content</P>"""
         full_xml = """
         <ROOT>
@@ -45,7 +46,8 @@ class NoticeSxsTests(TestCase):
 
         sxs = etree.fromstring("<ROOT>" + sxs_xml + "</ROOT>")
         #   Must use text field since the nodes are not directly comparable
-        sxs_texts = map(lambda el: el.text, list(sxs.xpath("/ROOT/*")))
+        sxs_texts = ['Sub Section', 'Content', 'Sub sub section',
+                     'This is in an extract', 'Sub Sub Content']
 
         computed = find_section_by_section(etree.fromstring(full_xml))
         self.assertEqual(sxs_texts, map(lambda el: el.text, computed))


### PR DESCRIPTION
For an unknown reason, paragraphs in the SxS section are sometimes wrapped in EXTRACT tags. This patch strips those tags from a copy of the notice's XML tree (so these changes shouldn't affect processing other parts of the notice).
