### PR TITLE
Add CODE-tag processing

### DIFF
--- a/regparser/tree/xml_parser/appendices.py
+++ b/regparser/tree/xml_parser/appendices.py
@@ -284,10 +284,10 @@ class AppendixProcessor(object):
         self._indent_if_needed()
         self.m_stack.add(self.depth, n)
 
-    def note(self, xml_node):
-        """Use github-like fencing to indicate this is a note"""
+    def fence(self, xml_node, fence_type):
+        """Use github-like fencing to indicate this is a note or code"""
         self.paragraph_counter += 1
-        texts = ["```note"]
+        texts = ["```" + fence_type]
         for child in xml_node:
             texts.append(tree_utils.get_node_text(child).strip())
         texts.append("```")
@@ -338,7 +338,9 @@ class AppendixProcessor(object):
             elif child.tag == 'GPOTABLE':
                 self.table(child)
             elif child.tag in ('NOTE', 'NOTES'):
-                self.note(child)
+                self.fence(child, 'note')
+            elif child.tag == 'CODE':
+                self.fence(child, child.get('LANGUAGE', 'code'))
 
         while self.m_stack.size() > 1:
             self.m_stack.unwind()

--- a/tests/tree_xml_parser_appendices_tests.py
+++ b/tests/tree_xml_parser_appendices_tests.py
@@ -277,6 +277,28 @@ class AppendicesTest(TestCase):
         text = '```note\nPar\nEmem\nParparpar\n```'
         self.assertEqual(note.text, text)
 
+    def test_process_code(self):
+        xml = u"""
+        <APPENDIX>
+            <HD SOURCE="HED">Appendix A to Part 1111—Awesome</HD>
+            <CODE LANGUAGE="scala">
+                <P>// Non-tail-recursive list reverse</P>
+                <FP SOURCE="FP-2">def rev[A](lst: List[A]):List[A] =</FP>
+                <FP SOURCE="FP-2">lst match {</FP>
+                <FP SOURCE="FP-2">  case Nil => Nil</FP>
+                <FP SOURCE="FP-2">  case head :: tail =></FP>
+                <FP SOURCE="FP-2">    rev(tail) ++ List(head)</FP>
+                <FP SOURCE="FP-2">}</FP>
+            </CODE>
+        </APPENDIX>"""
+        xml = etree.fromstring(xml)
+        appendix = appendices.process_appendix(xml, 1111)
+        self.assertEqual(['1111', 'A'], appendix.label)
+        self.assertEqual(1, len(appendix.children))
+        code = appendix.children[0]
+        text = "\n".join(p.text.strip() for p in xml.xpath("//P | //FP"))
+        self.assertEqual(code.text, "```scala\n" + text + "\n```")
+
     def test_initial_marker(self):
         self.assertEqual(("i", "i."), appendices.initial_marker("i. Hi"))
         self.assertEqual(("iv", "iv."), appendices.initial_marker("iv. Hi"))


### PR DESCRIPTION
This extends the existing "fenced" formatting logic to work with CODE tags. Previously it was only used for NOTE and NOTES tags.

Note not much code needed to change as this reuses a lot of the machinery set up for appendix "note"s
