### PR TITLE
Catch a few additional citations

### DIFF
--- a/regparser/citations.py
+++ b/regparser/citations.py
@@ -189,6 +189,8 @@ def internal_citations(text, initial_label=None, require_marker=False):
                        False)
     multiple_citations(grammar.multiple_comments.scanString(text), True)
     multiple_citations(grammar.multiple_appendices.scanString(text), False)
+    multiple_citations(grammar.multiple_period_sections.scanString(text),
+                       False)
 
     single_citations(grammar.marker_appendix.scanString(text), False)
     single_citations(grammar.appendix_with_section.scanString(text), False)
@@ -199,6 +201,8 @@ def internal_citations(text, initial_label=None, require_marker=False):
         single_citations(grammar.section_paragraph.scanString(text), False)
         single_citations(grammar.part_section_paragraph.scanString(text),
                          False)
+        multiple_citations(
+            grammar.multiple_section_paragraphs.scanString(text), False)
 
     # Some appendix citations are... complex
     for match, start, end in grammar.appendix_with_part.scanString(text):

--- a/regparser/grammar/unified.py
+++ b/regparser/grammar/unified.py
@@ -6,8 +6,8 @@ from pyparsing import Suppress, SkipTo
 from regparser.grammar import atomic
 from regparser.grammar.utils import keep_pos, Marker
 
-
-part_section = atomic.part + Suppress(".") + atomic.section
+period_section = Suppress(".") + atomic.section
+part_section = atomic.part + period_section
 marker_part_section = (
     atomic.section_marker.copy().setParseAction(keep_pos).setResultsName(
         "marker")
@@ -97,16 +97,30 @@ _inner_non_comment = (
     | (atomic.section + depth1_p)
     | appendix_with_section | marker_appendix)
 
+_inner_non_comment_tail = OneOrMore(
+    Optional(Suppress('('))
+    + atomic.conj_phrases
+    + _inner_non_comment.copy().setParseAction(keep_pos).setResultsName(
+        "tail", listAllMatches=True)
+    + Optional(Suppress(')')))
+
 multiple_non_comments = (
     (atomic.paragraphs_marker | atomic.paragraph_marker
         | atomic.sections_marker | atomic.section_marker)
     + _inner_non_comment.copy().setParseAction(keep_pos).setResultsName("head")
+    + _inner_non_comment_tail)
+
+multiple_section_paragraphs = (
+    section_paragraph.copy().setParseAction(keep_pos).setResultsName("head")
+    + _inner_non_comment_tail)
+
+multiple_period_sections = (
+    atomic.sections_marker
+    + part_section.copy().setParseAction(keep_pos).setResultsName("head")
     + OneOrMore(
-        Optional(Suppress('('))
-        + atomic.conj_phrases
-        + _inner_non_comment.copy().setParseAction(keep_pos).setResultsName(
-            "tail", listAllMatches=True)
-        + Optional(Suppress(')'))))
+        atomic.conj_phrases
+        + period_section.copy().setParseAction(keep_pos).setResultsName(
+            "tail", listAllMatches=True)))
 
 multiple_appendix_section = (
     appendix_with_section.copy().setParseAction(keep_pos).setResultsName(

--- a/tests/citations_tests.py
+++ b/tests/citations_tests.py
@@ -171,6 +171,16 @@ class CitationsTest(TestCase):
                          citation.label.to_list())
         self.assertEqual(to_text(citation, text), '(D)')
 
+        text = 'see 32(d)(6) and (7) Content content'
+        citations = internal_citations(text, Label(part='222'))
+        self.assertEqual(2, len(citations))
+        citation = citations[0]
+        self.assertEqual(['222', '32', 'd', '6'], citation.label.to_list())
+        self.assertEqual(to_text(citation, text), '32(d)(6)')
+        citation = citations[1]
+        self.assertEqual(['222', '32', 'd', '7'], citation.label.to_list())
+        self.assertEqual(to_text(citation, text), '(7)')
+
     def test_single_match_multiple_paragraphs2(self):
         text = u'§ 1005.10(a) and (d)'
         citations = internal_citations(text, Label(part='222', section='5'))
@@ -222,6 +232,13 @@ class CitationsTest(TestCase):
         text += 'and 1005.20'
         citations = internal_citations(text, Label(part='222', section='5'))
         self.assertEqual(7, len(citations))
+
+        text = 'Sections 1005.3, .4, and .5'
+        citations = internal_citations(text, Label(part='222', section='5'))
+        self.assertEqual(3, len(citations))
+        self.assertEqual(['1005', '3'], citations[0].label.to_list())
+        self.assertEqual(['1005', '4'], citations[1].label.to_list())
+        self.assertEqual(['1005', '5'], citations[2].label.to_list())
 
     def test_single_match_multiple_paragraphs3(self):
         text = "Please see E-9(a)(1), (2) and (d)(3)(v) for more"


### PR DESCRIPTION
Notably:

```
Sections 1111.33 through .38
```

and

```
No marker but still 33(a), (b), and (c)
```

We require a marker for the latter when finding internal citations, but not when processing SxS, Interpretation headers, etc.
