### PR TITLE
Don't duplicate SxS for headers with multiple labels; add a labels field

### DIFF
--- a/regparser/layer/section_by_section.py
+++ b/regparser/layer/section_by_section.py
@@ -10,10 +10,11 @@ class SectionBySection(Layer):
             search_results = []
 
             def per_sxs(sxs):
-                if ('label' in sxs and sxs['label'] == node.label_id()
+                if (node.label_id() in sxs.get('labels', [])
                     # Determine if this is non-empty
                     and (sxs['paragraphs']
-                         or [c for c in sxs['children'] if not 'label' in c])):
+                         or any(c for c in sxs['children']
+                                if not 'labels' in c))):
                     search_results.append(sxs)
                 for child in sxs['children']:
                     per_sxs(child)
@@ -27,7 +28,7 @@ class SectionBySection(Layer):
         if analyses:
             #   Sort by publication date
             analyses = sorted(analyses)
-            analyses = [{'reference': (n['document_number'], sxs['label']),
+            analyses = [{'reference': (n['document_number'], node.label_id()),
                          'publication_date': pub_date,
                          'fr_volume': n['fr_volume'],
                          'fr_page': sxs['page']}

--- a/regparser/notice/sxs.py
+++ b/regparser/notice/sxs.py
@@ -102,18 +102,16 @@ def build_section_by_section(sxs, part, fr_start_page, previous_label=None):
             'children': children,
             'footnote_refs': footnotes
             }
-        if not labels:
-            structures.append(next_structure)
-        for label in labels:
-            #   Concatenate if repeat label or backtrack (=ambiguous meaning)
-            if label == previous_label or is_backtrack(previous_label, label):
-                structures.append(next_structure)
-            else:
-                previous_label = label
-                part = previous_label.split('-')[0]  # part might change
-                cp_structure = dict(next_structure)  # shallow copy
-                cp_structure['label'] = label
-                structures.append(cp_structure)
+
+        if (labels   # No label => subheader
+                # Concatenate if repeat label or backtrack
+                and not all(label == previous_label
+                            or is_backtrack(previous_label, label)
+                            for label in labels)):
+            previous_label = labels[-1]
+            part = previous_label.split('-')[0]  # part might change
+            next_structure['labels'] = labels
+        structures.append(next_structure)
 
     return structures
 

--- a/tests/layer_section_by_section_tests.py
+++ b/tests/layer_section_by_section_tests.py
@@ -14,13 +14,13 @@ class LayerSectionBySectionTest(TestCase):
             'publication_date': '2008-08-08',
             "section_by_section": [{
                 "title": "",
-                "label": "100-22-b-2",
+                "labels": ["100-22-b-2"],
                 "paragraphs": ["AAA"],
                 "page": 7677,
                 "children": []
             }, {
                 "title": "",
-                "label": "100-22-b",
+                "labels": ["100-22-b"],
                 "paragraphs": ["BBB"],
                 "page": 7676,
                 "children": []
@@ -36,7 +36,7 @@ class LayerSectionBySectionTest(TestCase):
                 "paragraphs": [],
                 "children": [{
                     "title": "",
-                    "label": "100-22-b-2",
+                    "labels": ["100-22-b-2"],
                     "paragraphs": ["CCC"],
                     "page": 5454,
                     "children": []
@@ -68,7 +68,7 @@ class LayerSectionBySectionTest(TestCase):
             'publication_date': '2008-08-08',
             "section_by_section": [{
                 "title": "",
-                "label": "100-22-a",
+                "labels": ["100-22-a"],
                 "paragraphs": [],
                 "page": 7676,
                 "children": []
@@ -115,7 +115,7 @@ class LayerSectionBySectionTest(TestCase):
             "publication_date": "2010-10-10",
             "section_by_section": [{
                 "title": "",
-                "label": "100-22-b-2",
+                "labels": ["100-22-b-2"],
                 "paragraphs": ["AAA"],
                 "page": 7676,
                 "children": []
@@ -128,7 +128,7 @@ class LayerSectionBySectionTest(TestCase):
             "publication_date": "2009-09-09",
             "section_by_section": [{
                 "title": "",
-                "label": "100-22-b-2",
+                "labels": ["100-22-b-2"],
                 "paragraphs": ["CCC"],
                 "page": 5454,
                 "children": []

--- a/tests/notice_build_tests.py
+++ b/tests/notice_build_tests.py
@@ -102,7 +102,7 @@ class NoticeBuildTest(TestCase):
                 'children': [],
                 'footnote_refs': [],
                 'page': 100,
-                'label': '9292-8-q'
+                'labels': ['9292-8-q']
             }],
         })
 
@@ -129,7 +129,7 @@ class NoticeBuildTest(TestCase):
                 'children': [],
                 'footnote_refs': [],
                 'page': 210,
-                'label': '9292-8-q'
+                'labels': ['9292-8-q']
             }],
         })
 

--- a/tests/notice_sxs_tests.py
+++ b/tests/notice_sxs_tests.py
@@ -133,7 +133,7 @@ class NoticeSxsTests(TestCase):
         self.assertEqual(structures[1], {
             'title': '4(b) Header',
             'paragraphs': ['Content 5', 'Content 6'],
-            'label': '100-4-b',
+            'labels': ['100-4-b'],
             'page': 83,
             'footnote_refs': [],
             'children': []
@@ -176,13 +176,13 @@ class NoticeSxsTests(TestCase):
         self.assertEqual(1, len(structures))
         self.assertEqual(structures[0], {
             'title': 'Section 99.3 Info',
-            'label': '99-3',
+            'labels': ['99-3'],
             'paragraphs': ['Content 1'],
             'page': 2323,
             'footnote_refs': [],
             'children': [{
                 'title': '3(q)(4) More Info',
-                'label': '99-3-q-4',
+                'labels': ['99-3-q-4'],
                 'paragraphs': ['Content 2'],
                 'page': 2323,
                 'footnote_refs': [],
@@ -204,7 +204,7 @@ class NoticeSxsTests(TestCase):
         self.assertEqual(1, len(structures))
         self.assertEqual(structures[0], {
             'title': 'Section 99.3 Info',
-            'label': '99-3',
+            'labels': ['99-3'],
             'page': 939,
             'paragraphs': ['Content 1', 'Content  2',
                            'Content <em data-original="E-03">Emph</em>'],
@@ -229,13 +229,13 @@ class NoticeSxsTests(TestCase):
         self.assertEqual(1, len(structures))
         self.assertEqual(structures[0], {
             'title': 'Section 99.3 Something Here',
-            'label': '99-3',
+            'labels': ['99-3'],
             'paragraphs': [],
             'page': 765,
             'footnote_refs': [],
             'children': [{
                 'title': '3(q)(4) More Info',
-                'label': '99-3-q-4',
+                'labels': ['99-3-q-4'],
                 'paragraphs': ['Content 1'],
                 'page': 765,
                 'footnote_refs': [],
@@ -293,10 +293,10 @@ class NoticeSxsTests(TestCase):
         </ROOT>"""
         sxs = list(etree.fromstring(xml).xpath("/ROOT/*"))
         structures = build_section_by_section(sxs, '876', 23)
-        self.assertEqual(len(structures), 3)
-        self.assertEqual(structures[0]['label'], '876-22-a-Interp-5')
-        self.assertEqual(structures[1]['label'], '876-22-a-Interp-6')
-        self.assertEqual(structures[2]['label'], '876-22-b-Interp')
+        self.assertEqual(len(structures), 1)
+        self.assertEqual(structures[0]['labels'],
+                         ['876-22-a-Interp-5', '876-22-a-Interp-6',
+                          '876-22-b-Interp'])
 
     def test_build_section_by_section_repeat_label(self):
         xml = """
@@ -310,12 +310,12 @@ class NoticeSxsTests(TestCase):
         structures = build_section_by_section(sxs, '876', 23)
         self.assertEqual(len(structures), 1)
         struct1 = structures[0]
-        self.assertEqual(struct1['label'], '876-23-c')
+        self.assertEqual(struct1['labels'], ['876-23-c'])
         self.assertEqual(['Content 1'], struct1['paragraphs'])
         self.assertEqual(len(struct1['children']), 1)
         struct2 = struct1['children'][0]
         self.assertEqual(['Content 2'], struct2['paragraphs'])
-        self.assertFalse('label' in struct2)
+        self.assertFalse('labels' in struct2)
 
         # Now the same, but on the same H level
         xml = """
@@ -329,12 +329,12 @@ class NoticeSxsTests(TestCase):
         structures = build_section_by_section(sxs, '876', 23)
         self.assertEqual(len(structures), 1)
         struct1 = structures[0]
-        self.assertEqual(struct1['label'], '876-23-c')
+        self.assertEqual(struct1['labels'], ['876-23-c'])
         self.assertEqual(['Content 1'], struct1['paragraphs'])
         self.assertEqual(len(struct1['children']), 1)
         struct2 = struct1['children'][0]
         self.assertEqual(['Content 2'], struct2['paragraphs'])
-        self.assertFalse('label' in struct2)
+        self.assertFalse('labels' in struct2)
 
     def test_build_section_by_section_backtrack(self):
         xml = """
@@ -348,12 +348,12 @@ class NoticeSxsTests(TestCase):
         structures = build_section_by_section(sxs, '876', 23)
         self.assertEqual(len(structures), 1)
         struct1 = structures[0]
-        self.assertEqual(struct1['label'], '876-23-c-3')
+        self.assertEqual(struct1['labels'], ['876-23-c-3'])
         self.assertEqual(['Content 1'], struct1['paragraphs'])
         self.assertEqual(len(struct1['children']), 1)
         struct2 = struct1['children'][0]
         self.assertEqual(['Content 2'], struct2['paragraphs'])
-        self.assertFalse('label' in struct2)
+        self.assertFalse('labels' in struct2)
 
         # Same, but deeper H level
         xml = """
@@ -367,12 +367,12 @@ class NoticeSxsTests(TestCase):
         structures = build_section_by_section(sxs, '876', 23)
         self.assertEqual(len(structures), 1)
         struct1 = structures[0]
-        self.assertEqual(struct1['label'], '876-23-c-3')
+        self.assertEqual(struct1['labels'], ['876-23-c-3'])
         self.assertEqual(['Content 1'], struct1['paragraphs'])
         self.assertEqual(len(struct1['children']), 1)
         struct2 = struct1['children'][0]
         self.assertEqual(['Content 2'], struct2['paragraphs'])
-        self.assertFalse('label' in struct2)
+        self.assertFalse('labels' in struct2)
 
     def test_build_section_by_section_different_part(self):
         xml = """
@@ -386,11 +386,11 @@ class NoticeSxsTests(TestCase):
         structures = build_section_by_section(sxs, '876', 23)
         self.assertEqual(len(structures), 2)
         struct1, struct2 = structures
-        self.assertEqual(struct1['label'], '1111-23-c-3')
+        self.assertEqual(struct1['labels'], ['1111-23-c-3'])
         self.assertEqual(['Content 1'], struct1['paragraphs'])
         self.assertEqual(len(struct1['children']), 0)
 
-        self.assertEqual(struct2['label'], '1111-24-c')
+        self.assertEqual(struct2['labels'], ['1111-24-c'])
         self.assertEqual(['Content 2'], struct2['paragraphs'])
         self.assertEqual(len(struct2['children']), 0)
 
@@ -406,12 +406,39 @@ class NoticeSxsTests(TestCase):
         structures = build_section_by_section(sxs, '876', 23)
         self.assertEqual(len(structures), 1)
         struct1 = structures[0]
-        self.assertEqual(struct1['label'], '876-23-c-3')
+        self.assertEqual(struct1['labels'], ['876-23-c-3'])
         self.assertEqual(['Content 1'], struct1['paragraphs'])
         self.assertEqual(len(struct1['children']), 1)
         struct2 = struct1['children'][0]
         self.assertEqual(['Content 2'], struct2['paragraphs'])
-        self.assertFalse('label' in struct2)
+        self.assertFalse('labels' in struct2)
+
+    def test_build_section_by_section_dup_child(self):
+        xml = """
+        <ROOT>
+            <HD SOURCE="H2">References 31(a) and (b)</HD>
+            <P>Content 1</P>
+            <HD SOURCE="H3">Subcontent</HD>
+            <P>Content 2</P>
+            <HD SOURCE="H3">References 31(b)(1)</HD>
+            <P>Content 3</P>
+        </ROOT>"""
+        sxs = list(etree.fromstring(xml).xpath("/ROOT/*"))
+        structures = build_section_by_section(sxs, '876', 23)
+        self.assertEqual(len(structures), 1)
+        struct1 = structures[0]
+        self.assertEqual(struct1['labels'], ['876-31-a', '876-31-b'])
+        self.assertEqual(['Content 1'], struct1['paragraphs'])
+        self.assertEqual(len(struct1['children']), 2)
+        struct1_h, struct2 = struct1['children']
+
+        self.assertEqual(struct1_h['title'], 'Subcontent')
+        self.assertEqual(['Content 2'], struct1_h['paragraphs'])
+        self.assertEqual(len(struct1_h['children']), 0)
+
+        self.assertEqual(struct2['labels'], ['876-31-b-1'])
+        self.assertEqual(['Content 3'], struct2['paragraphs'])
+        self.assertEqual(len(struct2['children']), 0)
 
     def test_split_into_ttsr(self):
         xml = """


### PR DESCRIPTION
When encountering a SxS for "Paragraphs 33(b) and (c)", the code used to just copy the SxS. This leads to confusing bugs where the header contained subheaders, resulting in a single paragraph's SxS appear multiple times.

This solution is much cleaner. It replaces the "label" field with "labels", allowing a single SxS node to correspond to more than one label.
