### PR TITLE
More tweaks to SxS header processing

### DIFF
--- a/regparser/notice/sxs.py
+++ b/regparser/notice/sxs.py
@@ -151,7 +151,8 @@ def is_child_of(child_xml, header_xml, cfr_part, header_citations=None):
         child_citations = parse_into_labels(child_xml.text, cfr_part)
         if (child_xml.get('SOURCE') > header_xml.get('SOURCE')
                 or (header_citations and not child_citations)
-                or (header_citations and header_citations == child_citations)):
+                or (header_citations
+                    and header_citations[-1] == child_citations[0])):
             return True
         elif header_citations and child_citations:
             return is_backtrack(header_citations[-1].split('-'),
@@ -178,5 +179,9 @@ def parse_into_labels(txt, part):
     """Find what part+section+(paragraph) (could be multiple) this text is
     related to."""
     citations = internal_citations(txt, Label(part=part))
-    labels = ['-'.join(cit.label.to_list()) for cit in citations]
+    # odd corner case: headers shouldn't include both an appendix and regtext
+    labels = [c.label for c in citations]
+    if any('appendix' in l.settings for l in labels):
+        labels = [l for l in labels if 'appendix' in l.settings]
+    labels = ['-'.join(l.to_list()) for l in labels]
     return labels

--- a/tests/notice_sxs_tests.py
+++ b/tests/notice_sxs_tests.py
@@ -336,6 +336,25 @@ class NoticeSxsTests(TestCase):
         self.assertEqual(['Content 2'], struct2['paragraphs'])
         self.assertFalse('labels' in struct2)
 
+        # Semi-repeated
+        xml = """
+        <ROOT>
+            <HD SOURCE="H2">Appendices A and B</HD>
+            <P>Content 1</P>
+            <HD SOURCE="H2">Appendix B</HD>
+            <P>Content 2</P>
+        </ROOT>"""
+        sxs = list(etree.fromstring(xml).xpath("/ROOT/*"))
+        structures = build_section_by_section(sxs, '876', 23)
+        self.assertEqual(len(structures), 1)
+        struct1 = structures[0]
+        self.assertEqual(struct1['labels'], ['876-A', '876-B'])
+        self.assertEqual(['Content 1'], struct1['paragraphs'])
+        self.assertEqual(len(struct1['children']), 1)
+        struct2 = struct1['children'][0]
+        self.assertEqual(['Content 2'], struct2['paragraphs'])
+        self.assertFalse('labels' in struct2)
+
     def test_build_section_by_section_backtrack(self):
         xml = """
         <ROOT>
@@ -529,6 +548,9 @@ class NoticeSxsTests(TestCase):
         text = 'Section 1111.39Content content 1111.39(d) Exeptions'
         self.assertEqual(['1111-39', '1111-39-d'],
                          parse_into_labels(text, '101'))
+
+        text = "Appendix H—Closed-End Model Forms and Clauses-7(i)"
+        self.assertEqual(['101-H'], parse_into_labels(text, '101'))
 
     def test_is_child_of(self):
         parent = """<HD SOURCE="H2">Section 22.1</HD>"""


### PR DESCRIPTION
- Allow headers with only one label to be children of those with two (e.g. "Something about Appendix H" can be a child of "Something about Appendix G and Appendix H")
- When processing an appendix header, assume that any regtext citations are incorrect (e.g. ignore "2(a)" in "Appendix H - Model Form Clause 2(a)"
