### PR TITLE
Remove 'empty' diffs resulting from spaces at the end of text

### DIFF
--- a/regparser/diff/treediff.py
+++ b/regparser/diff/treediff.py
@@ -36,7 +36,9 @@ def deconstruct_text(text):
         words.append(text[s[0]:s[1]])
         # Update position
         last_space = s[1]
-    words.append(text[last_space:])
+    # Add the last bit of text (unless we've already grabbed it)
+    if last_space != len(text):
+        words.append(text[last_space:])
 
     return words
 

--- a/tests/diff_treediff.py
+++ b/tests/diff_treediff.py
@@ -63,6 +63,13 @@ class TreeDiffTest(TestCase):
         self.assertEquals(
             [('delete', 9, 19)], codes)
 
+    def test_ins_opcodes_trailing_space(self):
+        old = 'Howdy howdy. '
+        new = 'Howdy howdy. More content'
+        codes = treediff.get_opcodes(old, new)
+        self.assertEquals(
+            [('insert', 13, 'More content')], codes)
+
     def test_convert_insert(self):
         old = ['gg']
         new = ['ac', 'ef', 'bd']
@@ -127,6 +134,6 @@ class TreeDiffTest(TestCase):
 
         comparer = treediff.Compare(lhs, rhs)
         comparer.compare()
-        self.assertEqual(comparer.changes['1111'],
-            {'title': [[('delete', 0, 10), ('insert', 0, '')]],
-             'op': 'modified'})
+        self.assertEqual(
+            comparer.changes['1111'],
+            {'title': [('delete', 0, 10)], 'op': 'modified'})


### PR DESCRIPTION
This prevents diffs from presenting insertions/deletions of zero characters. Such deletions caused -site to crash.
