### PR TITLE
Account for multiple parents missing when compiling

### DIFF
--- a/regparser/notice/compiler.py
+++ b/regparser/notice/compiler.py
@@ -282,7 +282,7 @@ class RegulationTree(object):
 
     def create_empty_node(self, node_label):
         """ In rare cases, we need to flush out the tree by adding
-        an empty node. """
+        an empty node. Returns the created node"""
         node_label = node_label.split('-')
         if Node.INTERP_MARK in node_label:
             node_type = Node.INTERP
@@ -292,9 +292,11 @@ class RegulationTree(object):
             node_type = Node.REGTEXT
         node = Node(label=node_label, node_type=node_type)
         parent = self.get_parent(node)
+        if not parent:
+            parent = self.create_empty_node(get_parent_label(node))
         parent.children = self.add_child(parent.children, node,
                                          getattr(parent, 'child_labels', []))
-        return parent
+        return node
 
     def contains(self, label):
         """Is this label already in the tree? label can be a list or a

--- a/tests/notice_compiler_tests.py
+++ b/tests/notice_compiler_tests.py
@@ -742,6 +742,22 @@ class CompilerTests(TestCase):
         self.assertEqual(node.label, ['205', '3', Node.INTERP_MARK])
         self.assertEqual(node.node_type, Node.INTERP)
 
+    def test_create_empty_recursive(self):
+        root = self.tree_with_paragraphs()
+        reg_tree = compiler.RegulationTree(root)
+        reg_tree.create_empty_node('205-4-a-2')
+
+        node = find(reg_tree.tree, '205-4')
+        self.assertEqual(1, len(node.children))
+        node = node.children[0]
+
+        self.assertEqual(['205', '4', 'a'], node.label)
+        self.assertEqual(1, len(node.children))
+        node = node.children[0]
+
+        self.assertEqual(['205', '4', 'a', '2'], node.label)
+        self.assertEqual(0, len(node.children))
+
     def test_add_node_no_parent(self):
         root = self.tree_with_paragraphs()
         reg_tree = compiler.RegulationTree(root)


### PR DESCRIPTION
At points (particularly in interpretations), we want to insert a node that's missing a parent. The compiler used to add a single empty parent in this case.

This patch expands that logic to be recursively add parents, which reduces the number of manual tweaks to interpretations needed.
