### PR TITLE
Sync https://github.com/18F/regulations-parser/pull/11

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Here's an example, using CFPB's regulation H.
 1. `cd regulations-parser`
 1. `pip install -r requirements.txt`
 1. `wget http://www.gpo.gov/fdsys/pkg/CFR-2012-title12-vol8/xml/CFR-2012-title12-vol8-part1004.xml`
-1. `python build_from.py CFR-2012-title12-vol8-part1004.xml 12 2011-18676 15 1693`
+1. `python build_from.py CFR-2012-title12-vol8-part1004.xml 12 15 1693`
 
 At the end, you will have new directories for `regulation`, `layer`,
 `diff`, and `notice` which would mirror the JSON files sent to the API.

--- a/README.md
+++ b/README.md
@@ -20,10 +20,8 @@ Here's an example, using CFPB's regulation H.
 1. `git clone https://github.com/cfpb/regulations-parser.git`
 1. `cd regulations-parser`
 1. `pip install -r requirements.txt`
-1. `wget
-   http://www.gpo.gov/fdsys/pkg/CFR-2012-title12-vol8/xml/CFR-2012-title12-vol8-part1004.xml`
-1. `python build_from.py CFR-2012-title12-vol8-part1004.xml 12 2011-18676 15
-   1693`
+1. `wget http://www.gpo.gov/fdsys/pkg/CFR-2012-title12-vol8/xml/CFR-2012-title12-vol8-part1004.xml`
+1. `python build_from.py CFR-2012-title12-vol8-part1004.xml 12 2011-18676 15 1693`
 
 At the end, you will have new directories for `regulation`, `layer`,
 `diff`, and `notice` which would mirror the JSON files sent to the API.
@@ -38,7 +36,7 @@ tweaked to pass the parser.
 1. `git clone https://github.com/cfpb/fr-notices.git`
 1. `pip install -r requirements.txt`
 1. `echo "LOCAL_XML_PATHS = ['fr-notices']" >> local_settings.py`
-1. `python build_from.py fr-notices/articles/xml/201/131/725.xml 12 2011-31725 15 1693`
+1. `python build_from.py fr-notices/articles/xml/201/131/725.xml 12 15 1693`
 
 If you review the history of the `fr-notices` repo, you'll see some of the types of changes that need to be made.
 
@@ -149,27 +147,19 @@ regulation E).
 The syntax is 
 
 ```bash
-$ python build_from.py regulation.ext title notice_doc_# act_title act_section
+$ python build_from.py regulation.ext title act_title act_section
 ```
 
-For example, to match the reissuance above:
+For example, to match regulation H in the quick start above:
 ```bash
-$ python build_from.py 725.xml 12 2013-1725 15 1693
+$ python build_from.py CFR-2012-title12-vol8-part1004.xml 12 15 1693
 ```
 
 Here ```12``` is the CFR title number (in our case, for "Banks and
-Banking"), ```2013-1725``` is the last notice used to create this version
-(i.e. the last "final rule" which is currently in effect), ```15``` is the
+Banking"), ```15``` is the
 title of "the Act" and ```1693``` is the relevant section. Wherever the
 phrase "the Act" is used in the regulation, the external link parser will
-treat it as "15 U.S.C. 1693".  The final rule number is used to pull in
-section-by-section analyses and deduce which notices were used to create
-this version of the regulation. It also helps determine which notices to use
-when building additional versions of the regulation. To find the document
-number, use the [Federal Register](https://www.federalregister.gov/),
-finding the last, effective final rule for your version of the regulation
-and copying the document number from the meta data (currently in a table on
-the right side).
+treat it as "15 U.S.C. 1693".
 
 Running the command will generate four folders, ```regulation```,
 ```notice```, ``layer`` and possibly ``diff`` in the ```OUTPUT_DIR```
@@ -519,8 +509,7 @@ the regulation H example above
 
  1. `cd /path/to/regulations-parser`
  1. `echo "API_BASE = 'http://127.0.0.0:8888/'" >> local_settings.py`
- 1. `python build_from.py CFR-2012-title12-vol8-part1004.xml 12 2011-18676 15
-   1693`
+ 1. `python build_from.py CFR-2012-title12-vol8-part1004.xml 12 15 1693`
 
 Next up, we set up [regulations-site](https://github.com/cfpb/regulations-site) to provide a webapp.
 

--- a/build_from.py
+++ b/build_from.py
@@ -4,6 +4,7 @@ import codecs
 import logging
 import argparse
 
+
 try:
     import requests_cache
     requests_cache.install_cache('fr_cache')
@@ -21,22 +22,27 @@ logger.addHandler(logging.StreamHandler())
 
 # @profile
 def parse_regulation(args):
-    """ Run the parser on the specified command-line arguments. Broken out into
-        separate function to assist in profiling.
+    """ Run the parser on the specified command-line arguments. Broken out
+    into separate function to assist in profiling.
     """
     with codecs.open(args.filename, 'r', 'utf-8') as f:
         reg = f.read()
 
-    doc_number = args.notice
-    act_title_and_section = [args.act_title, args.act_section]
-
     #   First, the regulation tree
     reg_tree = Builder.reg_tree(reg)
 
+    title_part = reg_tree.label_id()
+
+    doc_number = Builder.determine_doc_number(reg, args.title, title_part)
+    if not doc_number:
+        raise ValueError("Could not determine document number")
+
+    act_title_and_section = [args.act_title, args.act_section]
+
+    #   Run Builder
     builder = Builder(cfr_title=args.title,
                       cfr_part=reg_tree.label_id(),
                       doc_number=doc_number)
-
     builder.write_notices()
 
     #   Always do at least the first reg
@@ -47,12 +53,15 @@ def parse_regulation(args):
     layer_cache.replace_using(reg_tree)
 
     if args.generate_diffs:
-        generate_diffs(doc_number, reg_tree, act_title_and_section, builder, layer_cache)
+        generate_diffs(doc_number, reg_tree, act_title_and_section, builder,
+                       layer_cache)
 
-def generate_diffs(doc_number, reg_tree, act_title_and_section, builder, layer_cache):
-    """ Generate all the diffs for the given regulation. Broken out into separate function
-        to assist with profiling so it's easier to determine which parts of the parser take
-        the most time
+
+def generate_diffs(doc_number, reg_tree, act_title_and_section, builder,
+                   layer_cache):
+    """ Generate all the diffs for the given regulation. Broken out into
+    separate function to assist with profiling so it's easier to determine
+    which parts of the parser take the most time
     """
 
     all_versions = {doc_number: reg_tree}
@@ -84,11 +93,11 @@ if __name__ == "__main__":
     parser.add_argument('filename',
                         help='XML file containing the regulation')
     parser.add_argument('title', type=int, help='Title number')
-    parser.add_argument('notice', type=str, help='Notice document number')
-    parser.add_argument('act_title', type=int, help='Act title', action='store')
+    parser.add_argument('act_title', type=int, help='Act title',
+                        action='store')
     parser.add_argument('act_section', type=int, help='Act section')
-    parser.add_argument('--generate-diffs', type=bool, help='Generate diffs?', required=False, default=True)
+    parser.add_argument('--generate-diffs', type=bool, help='Generate diffs?',
+                        required=False, default=True)
 
     args = parser.parse_args()
-    
     parse_regulation(args)

--- a/regparser/federalregister.py
+++ b/regparser/federalregister.py
@@ -6,7 +6,8 @@ FR_BASE = "https://www.federalregister.gov"
 API_BASE = FR_BASE + "/api/v1/"
 
 
-def fetch_notice_json(cfr_title, cfr_part, only_final=False):
+def fetch_notice_json(cfr_title, cfr_part, only_final=False,
+                      max_effective_date=None):
     """Search through all articles associated with this part. Right now,
     limited to 1000; could use paging to fix this in the future."""
     params = {
@@ -21,6 +22,8 @@ def fetch_notice_json(cfr_title, cfr_part, only_final=False):
             "regulation_id_numbers", "start_page", "type", "volume"]}
     if only_final:
         params["conditions[type][]"] = 'RULE'
+    if max_effective_date:
+        params["conditions[effective_date][lte]"] = max_effective_date
     response = requests.get(API_BASE + "articles", params=params).json()
     if 'results' in response:
         return response['results']

--- a/regparser/tree/struct.py
+++ b/regparser/tree/struct.py
@@ -10,9 +10,8 @@ class Node(object):
 
     INTERP_MARK = 'Interp'
 
-    def __init__(
-        self, text='', children=[], label=[], title=None,
-            node_type=REGTEXT, source_xml=None):
+    def __init__(self, text='', children=[], label=[], title=None,
+                 node_type=REGTEXT, source_xml=None):
 
         self.text = unicode(text)
 


### PR DESCRIPTION
This is a hand-merged version of #267 to account for our out-of-syncness

@thejennywang and @lauraGgit 's original PR removed the need to specify the notice document number when running the parser pipeline.