### PR TITLE
Pull in latest 18f work

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,21 @@ regulation. To include all final notices, add this flag:
 $ python notice_order.py 12 1005 --include-notices-without-changes
 ```
 
+### Watch Node
+
+Tracing how a specific node changes over the life of a regulation can help
+track down why the parser is failing (or exploding). The `watch_node.py`
+utility does exactly that, stepping through the initial tree and all
+subsequent notices. Whenever a node is changed (created, modified, deleted,
+etc.) this utility will log some output.
+
+```
+$ python watch_node.py 1005-16-c path/to/regulation.xml 12
+```
+
+The first parameter is the label of the node you want to watch, the second is
+the initial regulation XML file and the final parameter is the CFR title.
+
 
 ## Building the documentation
 

--- a/build_from.py
+++ b/build_from.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
 import argparse
-import codecs
-import hashlib
 import logging
 
 try:
@@ -13,8 +11,7 @@ except ImportError:
     # HTTP requests rather than looking it up from the cache
     pass
 
-from regparser.builder import (
-    Builder, Checkpointer, LayerCacheAggregator, NullCheckpointer)
+from regparser.builder import LayerCacheAggregator, tree_and_builder
 from regparser.diff.tree import changes_between
 from regparser.tree.struct import FrozenNode
 
@@ -22,43 +19,20 @@ logger = logging.getLogger('build_from')
 logger.setLevel(logging.INFO)
 logger.addHandler(logging.StreamHandler())
 
+
 # @profile
 def parse_regulation(args):
     """ Run the parser on the specified command-line arguments. Broken out
         into separate function to assist in profiling.
     """
-    with codecs.open(args.filename, 'r', 'utf-8') as f:
-        reg = f.read()
-        file_digest = hashlib.sha256(reg.encode('utf-8')).hexdigest()
     act_title_and_section = [args.act_title, args.act_section]
-
-    if args.checkpoint:
-        checkpointer = Checkpointer(args.checkpoint)
-    else:
-        checkpointer = NullCheckpointer()
-
     #   First, the regulation tree
-    reg_tree = checkpointer.checkpoint(
-        "init-tree-" + file_digest,
-        lambda: Builder.reg_tree(reg))
-    title_part = reg_tree.label_id()
-    doc_number = checkpointer.checkpoint(
-        "doc-number-" + file_digest,
-        lambda: Builder.determine_doc_number(reg, args.title, title_part))
-    if not doc_number:
-        raise ValueError("Could not determine document number")
-    checkpointer.suffix = ":".join(
-        ["", title_part, str(args.title), doc_number])
-
-    #   Run Builder
-    builder = Builder(cfr_title=args.title,
-                      cfr_part=title_part,
-                      doc_number=doc_number,
-                      checkpointer=checkpointer)
+    reg_tree, builder = tree_and_builder(args.filename, args.title,
+                                         args.checkpoint)
     builder.write_notices()
 
     #   Always do at least the first reg
-    logger.info("Version %s", doc_number)
+    logger.info("Version %s", builder.doc_number)
     builder.write_regulation(reg_tree)
     layer_cache = LayerCacheAggregator()
 
@@ -66,15 +40,14 @@ def parse_regulation(args):
     layer_cache.replace_using(reg_tree)
 
     if args.generate_diffs:
-        generate_diffs(doc_number, reg_tree, act_title_and_section, builder,
-                       layer_cache, checkpointer)
+        generate_diffs(reg_tree, act_title_and_section, builder, layer_cache)
 
 
-def generate_diffs(doc_number, reg_tree, act_title_and_section, builder,
-                   layer_cache, checkpointer):
+def generate_diffs(reg_tree, act_title_and_section, builder, layer_cache):
     """ Generate all the diffs for the given regulation. Broken out into
         separate function to assist with profiling so it's easier to determine
         which parts of the parser take the most time """
+    doc_number, checkpointer = builder.doc_number, builder.checkpointer
     all_versions = {doc_number: FrozenNode.from_node(reg_tree)}
 
     for last_notice, old, new_tree, notices in builder.revision_generator(
@@ -113,8 +86,12 @@ if __name__ == "__main__":
     parser.add_argument('act_title', type=int, help='Act title',
                         action='store')
     parser.add_argument('act_section', type=int, help='Act section')
-    parser.add_argument('--generate-diffs', type=bool, help='Generate diffs?',
-                        required=False, default=True)
+    diffs = parser.add_mutually_exclusive_group(required=False)
+    diffs.add_argument('--generate-diffs', dest='generate_diffs',
+                       action='store_true', help='Generate diffs')
+    diffs.add_argument('--no-generate-diffs', dest='generate_diffs',
+                       action='store_false', help="Don't generate diffs")
+    diffs.set_defaults(generate_diffs=True)
     parser.add_argument('--checkpoint', required=False,
                         help='Directory to save checkpoint data')
 

--- a/regparser/grammar/tokens.py
+++ b/regparser/grammar/tokens.py
@@ -51,6 +51,7 @@ class Verb(Token):
     DELETE = 'DELETE'
     DESIGNATE = 'DESIGNATE'
     RESERVE = 'RESERVE'
+    KEEP = 'KEEP'
 
     def __init__(self, verb, active, and_prefix=False):
         self.verb = verb

--- a/regparser/notice/changes.py
+++ b/regparser/notice/changes.py
@@ -6,6 +6,7 @@ import logging
 import copy
 from collections import defaultdict
 
+from regparser.grammar.tokens import Verb
 from regparser.layer.paragraph_markers import marker_of
 from regparser.tree import struct
 from regparser.tree.paragraph import p_levels
@@ -191,7 +192,7 @@ def create_add_amendment(amendment):
         # Text is stars, but this is not the root. Explicitly try to keep
         # this node
         if text == '* * *':
-            change[label]['action'] = 'KEEP'
+            change[label]['action'] = Verb.KEEP
 
         # If text ends with a colon and is followed by stars, assume we are
         # only modifying the intro text
@@ -238,6 +239,31 @@ def remove_intro(l):
     """ Remove the marker that indicates this is a change to introductory
     text. """
     return l.replace('[text]', '')
+
+
+def pretty_change(change):
+    """Pretty print output for a change"""
+    node = change.get('node')
+    field = change.get('field')
+    if change['action'] == Verb.PUT and field:
+        return '%s changed to: %s' % (field.strip('[]').title(),
+                                      node.get('title', node['text']))
+    elif change['action'] in (Verb.PUT, Verb.POST):
+        verb = 'Modified' if change['action'] == Verb.PUT else 'Added'
+        if node.get('title'):
+            return verb + ' (title: %s): %s' % (node['title'], node['text'])
+        else:
+            return verb + ": " + node['text']
+    elif change['action'] == Verb.DELETE:
+        return 'Deleted'
+    elif change['action'] == Verb.DESIGNATE:
+        return 'Moved to ' + '-'.join(change['destination'])
+    elif change['action'] == Verb.RESERVE:
+        return 'Reserved'
+    elif change['action'] == Verb.KEEP:
+        return 'Mentioned but not modified'
+    else:
+        return change['action']
 
 
 class NoticeChanges(object):

--- a/regparser/notice/compiler.py
+++ b/regparser/notice/compiler.py
@@ -7,6 +7,7 @@ import copy
 import itertools
 import logging
 
+from regparser.grammar.tokens import Verb
 from regparser.tree.struct import Node, find
 from regparser.tree.xml_parser import interpretations
 from regparser.tree.xml_parser import tree_utils
@@ -393,7 +394,7 @@ class RegulationTree(object):
     def create_new_subpart(self, subpart_label):
         """ Create a whole new subpart. """
 
-        #XXX Subparts need titles. We'll need to pull this up from parsing.
+        # XXX Subparts need titles. We'll need to pull this up from parsing.
         subpart_node = Node('', [], subpart_label, None, Node.SUBPART)
         self.add_to_root(subpart_node)
         return subpart_node
@@ -453,7 +454,7 @@ def sort_labels(labels):
     """ Deal with higher up elements first. """
     sorted_labels = sorted(labels, key=lambda x: len(x))
 
-    #The length of a Subpart label doesn't indicate it's level in the tree
+    # The length of a Subpart label doesn't indicate it's level in the tree
     subparts = [l for l in sorted_labels if 'Subpart' in l]
     non_subparts = [l for l in sorted_labels if 'Subpart' not in l]
 
@@ -530,8 +531,8 @@ def compile_regulation(previous_tree, notice_changes):
                  for change in notice_changes[label]]
     pass_len = len(next_pass) + 1
 
-    reg.keep(l for l, change in next_pass if change['action'] == 'KEEP')
-    next_pass = [pair for pair in next_pass if pair[1]['action'] != 'KEEP']
+    reg.keep(l for l, change in next_pass if change['action'] == Verb.KEEP)
+    next_pass = [pair for pair in next_pass if pair[1]['action'] != Verb.KEEP]
 
     #   Monotonically decreasing length - guarantees we'll end
     while pass_len > len(next_pass):

--- a/regparser/tree/struct.py
+++ b/regparser/tree/struct.py
@@ -207,6 +207,7 @@ class FrozenNode(object):
         (this is a Merkle tree)"""
         return (other.__class__ == self.__class__
                 and self.hash == other.hash
+                # Compare the fields to limit the effect of hash collisions
                 and self.text == other.text
                 and self.title == other.title
                 and self.node_type == other.node_type

--- a/regparser/tree/xml_parser/reg_text.py
+++ b/regparser/tree/xml_parser/reg_text.py
@@ -1,4 +1,4 @@
-#vim: set encoding=utf-8
+# vim: set encoding=utf-8
 import re
 
 from lxml import etree
@@ -15,20 +15,31 @@ from regparser.tree.xml_parser import tree_utils
 
 def get_reg_part(reg_doc):
     """
-    The CFR Part number for a regulation is contained within
-    an EAR tag, for a Federal Register notice it's in a REGTEXT tag. Get the
-    part number of the regulation.
+    Depending on source, the CFR part number exists in different places. Fetch
+    it, wherever it is.
     """
 
-    #FR notice
-    reg_text_xml = reg_doc.xpath('//REGTEXT')
-    if reg_text_xml:
-        return reg_text_xml[0].attrib['PART']
+    potential_parts = []
+    potential_parts.extend(
+        # FR notice
+        node.attrib['PART'] for node in reg_doc.xpath('//REGTEXT'))
+    potential_parts.extend(
+        # e-CFR XML, under PART/EAR
+        node.text.replace('Pt.', '').strip()
+        for node in reg_doc.xpath('//PART/EAR')
+        if 'Pt.' in node.text)
+    potential_parts.extend(
+        # e-CFR XML, under FDSYS/HEADING
+        node.text.replace('PART', '').strip()
+        for node in reg_doc.xpath('//FDSYS/HEADING')
+        if 'PART' in node.text)
+    potential_parts.extend(
+        # e-CFR XML, under FDSYS/GRANULENUM
+        node.text.strip() for node in reg_doc.xpath('//FDSYS/GRANULENUM'))
+    potential_parts = [p for p in potential_parts if p.strip()]
 
-    #e-CFR XML
-    reg_ear = reg_doc.xpath('//PART/EAR')
-    if reg_ear:
-        return reg_ear[0].text.split('Pt.')[1].strip()
+    if potential_parts:
+        return potential_parts[0]
 
 
 def get_title(reg_doc):
@@ -208,7 +219,7 @@ def build_from_section(reg_part, section_xml):
 
     # Use constraint programming to figure out possible depth assignments
     depths = derive_depths(
-        [n.label[0] for n in nodes],
+        [node.label[0] for node in nodes],
         [rules.depth_type_order([mtypes.lower, mtypes.ints, mtypes.roman,
                                  mtypes.upper, mtypes.em_ints,
                                  mtypes.em_roman])])

--- a/tests/notice_changes_tests.py
+++ b/tests/notice_changes_tests.py
@@ -1,4 +1,4 @@
-#vim: set encoding=utf-8
+# vim: set encoding=utf-8
 from unittest import TestCase
 from regparser.notice import changes
 from regparser.tree.struct import Node, find
@@ -226,6 +226,47 @@ class ChangesTests(TestCase):
 
         node = Node('', label=['205', '35', 'c', '1', 'i'])
         self.assertFalse(changes.impossible_label(node, amended_labels))
+
+    def test_pretty_changes(self):
+        """Verify the output for a variety of "changes" """
+        self.assertEqual(
+            changes.pretty_change({'action': 'DELETE'}), 'Deleted')
+        self.assertEqual(
+            changes.pretty_change({'action': 'RESERVE'}), 'Reserved')
+        self.assertEqual(
+            changes.pretty_change({'action': 'KEEP'}),
+            'Mentioned but not modified')
+        self.assertEqual(
+            changes.pretty_change({'action': 'DESIGNATE',
+                                   'destination': ['123', '43', 'a', '2']}),
+            'Moved to 123-43-a-2')
+
+        node = {'text': 'Some Text'}
+        change = {'action': 'PUT', 'node': node}
+        self.assertEqual(
+            changes.pretty_change(change), 'Modified: Some Text')
+
+        change['action'] = 'POST'
+        self.assertEqual(
+            changes.pretty_change(change), 'Added: Some Text')
+
+        node['title'] = 'A Title'
+        self.assertEqual(
+            changes.pretty_change(change), 'Added (title: A Title): Some Text')
+
+        change['action'] = 'PUT'
+        self.assertEqual(
+            changes.pretty_change(change),
+            'Modified (title: A Title): Some Text')
+
+        change['field'] = '[title]'
+        self.assertEqual(
+            changes.pretty_change(change), 'Title changed to: A Title')
+
+        del node['title']
+        change['field'] = '[a field]'
+        self.assertEqual(
+            changes.pretty_change(change), 'A Field changed to: Some Text')
 
 
 class NoticeChangesTests(TestCase):

--- a/tests/tree_xml_parser_reg_text_tests.py
+++ b/tests/tree_xml_parser_reg_text_tests.py
@@ -37,7 +37,7 @@ class RegTextTest(TestCase):
                 <P>bop means baz</P>
             </SECTION>
         """
-        node = build_from_section('8675', etree.fromstring(xml))[0]
+        node = reg_text.build_from_section('8675', etree.fromstring(xml))[0]
         self.assertEqual('', node.text.strip())
         self.assertEqual(1, len(node.children))
         self.assertEqual(['8675', '309'], node.label)

--- a/tests/tree_xml_parser_reg_text_tests.py
+++ b/tests/tree_xml_parser_reg_text_tests.py
@@ -1,10 +1,10 @@
-#vim: set encoding=utf-8
+# vim: set encoding=utf-8
 from unittest import TestCase
 
 from lxml import etree
 from mock import patch
 
-from regparser.tree.xml_parser.reg_text import *
+from regparser.tree.xml_parser import reg_text
 
 
 class RegTextTest(TestCase):
@@ -17,7 +17,7 @@ class RegTextTest(TestCase):
                 <P>(a) something something</P>
             </SECTION>
         """
-        node = build_from_section('8675', etree.fromstring(xml))[0]
+        node = reg_text.build_from_section('8675', etree.fromstring(xml))[0]
         self.assertEqual('Some content about this section.', node.text.strip())
         self.assertEqual(1, len(node.children))
         self.assertEqual(['8675', '309'], node.label)
@@ -63,7 +63,7 @@ class RegTextTest(TestCase):
             <P>(b) <E T="03">Contents</E> (1) Here</P>
         </SECTION>
         """
-        node = build_from_section('8675', etree.fromstring(xml))[0]
+        node = reg_text.build_from_section('8675', etree.fromstring(xml))[0]
         self.assertEqual(node.label, ['8675', '309'])
         self.assertEqual(2, len(node.children))
         self.assertEqual(node.children[0].label, ['8675', '309', 'a'])
@@ -85,7 +85,7 @@ class RegTextTest(TestCase):
                 <P>(A) AAA—(<E T="03">1</E>) eeee</P>
             </SECTION>
         """
-        node = build_from_section('8675', etree.fromstring(xml))[0]
+        node = reg_text.build_from_section('8675', etree.fromstring(xml))[0]
         a1iA = node.children[0].children[0].children[0].children[0]
         self.assertEqual(u"(A) AAA—", a1iA.text)
         self.assertEqual(1, len(a1iA.children))
@@ -100,7 +100,7 @@ class RegTextTest(TestCase):
                 <P>(ii) Content2</P>
             </SECTION>
         """
-        node = build_from_section('8675', etree.fromstring(xml))[0]
+        node = reg_text.build_from_section('8675', etree.fromstring(xml))[0]
         self.assertEqual(['8675', '309'], node.label)
         self.assertEqual(1, len(node.children))
 
@@ -122,7 +122,7 @@ class RegTextTest(TestCase):
                 <SECTNO>§ 8675.309</SECTNO>
                 <RESERVED>[Reserved]</RESERVED>
             </SECTION>"""
-        node = build_from_section('8675', etree.fromstring(xml))[0]
+        node = reg_text.build_from_section('8675', etree.fromstring(xml))[0]
         self.assertEqual(node.label, ['8675', '309'])
         self.assertEqual(u'§ 8675.309 [Reserved]', node.title)
         self.assertEqual([], node.children)
@@ -133,7 +133,8 @@ class RegTextTest(TestCase):
                 <SECTNO>§§ 8675.309-8675.311</SECTNO>
                 <RESERVED>[Reserved]</RESERVED>
             </SECTION>"""
-        n309, n310, n311 = build_from_section('8675', etree.fromstring(xml))
+        n309, n310, n311 = reg_text.build_from_section(
+            '8675', etree.fromstring(xml))
         self.assertEqual(n309.label, ['8675', '309'])
         self.assertEqual(n310.label, ['8675', '310'])
         self.assertEqual(n311.label, ['8675', '311'])
@@ -154,16 +155,16 @@ class RegTextTest(TestCase):
                 <P>%s</P>
             </SECTION>
         """
-        n8675_309 = build_from_section('8675',
-                                       etree.fromstring(xml % '(ii) A'))[0]
+        n8675_309 = reg_text.build_from_section(
+            '8675', etree.fromstring(xml % '(ii) A'))[0]
         n8675_309_h = n8675_309.children[1]
         n8675_309_h_2 = n8675_309_h.children[1]
         self.assertEqual(2, len(n8675_309.children))
         self.assertEqual(2, len(n8675_309_h.children))
         self.assertEqual(2, len(n8675_309_h_2.children))
 
-        n8675_309 = build_from_section('8675',
-                                       etree.fromstring(xml % '(A) B'))[0]
+        n8675_309 = reg_text.build_from_section(
+            '8675', etree.fromstring(xml % '(A) B'))[0]
         n8675_309_h = n8675_309.children[1]
         n8675_309_h_2 = n8675_309_h.children[1]
         n8675_309_h_2_i = n8675_309_h_2.children[0]
@@ -172,12 +173,12 @@ class RegTextTest(TestCase):
         self.assertEqual(1, len(n8675_309_h_2.children))
         self.assertEqual(1, len(n8675_309_h_2_i.children))
 
-        n8675_309 = build_from_section('8675',
-                                       etree.fromstring(xml % '(1) C'))[0]
+        n8675_309 = reg_text.build_from_section(
+            '8675', etree.fromstring(xml % '(1) C'))[0]
         self.assertEqual(3, len(n8675_309.children))
 
-        n8675_309 = build_from_section('8675',
-                                       etree.fromstring(xml % '(3) D'))[0]
+        n8675_309 = reg_text.build_from_section(
+            '8675', etree.fromstring(xml % '(3) D'))[0]
         n8675_309_h = n8675_309.children[1]
         n8675_309_h_2 = n8675_309_h.children[1]
         self.assertEqual(2, len(n8675_309.children))
@@ -195,7 +196,7 @@ class RegTextTest(TestCase):
                 <P>(B) BBB</P>
             </SECTION>
         """
-        n309 = build_from_section('8675', etree.fromstring(xml))[0]
+        n309 = reg_text.build_from_section('8675', etree.fromstring(xml))[0]
         self.assertEqual(1, len(n309.children))
         n309_a = n309.children[0]
         self.assertEqual(2, len(n309_a.children))
@@ -217,7 +218,7 @@ class RegTextTest(TestCase):
                 <P>\n(<E T="03">2</E>) i2i2i2</P>
             </SECTION>
         """
-        node = build_from_section('8675', etree.fromstring(xml))[0]
+        node = reg_text.build_from_section('8675', etree.fromstring(xml))[0]
         self.assertEqual(1, len(node.children))
         self.assertEqual(node.label, ['8675', '309'])
 
@@ -250,7 +251,7 @@ class RegTextTest(TestCase):
                 <P>(b)<E T="03">General.</E>Content Content.</P>
             </SECTION>
         """
-        node = build_from_section('8675', etree.fromstring(xml))[0]
+        node = reg_text.build_from_section('8675', etree.fromstring(xml))[0]
         self.assertEqual(1, len(node.children))
         nb = node.children[0]
         self.assertEqual(nb.text.strip(), "(b) General. Content Content.")
@@ -260,17 +261,19 @@ class RegTextTest(TestCase):
             <PART>
                 <HD>regulation title</HD>
             </PART>"""
-        title = get_title(etree.fromstring(xml))
+        title = reg_text.get_title(etree.fromstring(xml))
         self.assertEqual(u'regulation title', title)
 
     def test_get_reg_part(self):
-        xml = u"""
-            <PART>
-                <EAR> Pt. 204 </EAR>
-            </PART>
-        """
-        part = get_reg_part(etree.fromstring(xml))
-        self.assertEqual(part, '204')
+        """Test various formats for the Regulation part to be present in a
+        CFR-XML document"""
+        xmls = []
+        xmls.append(u"<PART><EAR>Pt. 204</EAR></PART>")
+        xmls.append(u"<FDSYS><HEADING>PART 204</HEADING></FDSYS>")
+        xmls.append(u"<FDSYS><GRANULENUM>204</GRANULENUM></FDSYS>")
+        for xml_str in xmls:
+            part = reg_text.get_reg_part(etree.fromstring(xml_str))
+            self.assertEqual(part, '204')
 
     def test_get_reg_part_fr_notice_style(self):
         xml = u"""
@@ -279,7 +282,7 @@ class RegTextTest(TestCase):
             </SECTION>
             </REGTEXT>
         """
-        part = get_reg_part(etree.fromstring(xml))
+        part = reg_text.get_reg_part(etree.fromstring(xml))
         self.assertEqual(part, '204')
 
     def test_get_subpart_title(self):
@@ -287,7 +290,7 @@ class RegTextTest(TestCase):
             <SUBPART>
                 <HD>Subpart A—First subpart</HD>
             </SUBPART>"""
-        subpart_title = get_subpart_title(etree.fromstring(xml))
+        subpart_title = reg_text.get_subpart_title(etree.fromstring(xml))
         self.assertEqual(subpart_title, u'Subpart A—First subpart')
 
     def test_build_subpart(self):
@@ -308,7 +311,7 @@ class RegTextTest(TestCase):
             </SECTION>
             </SUBPART>
         """
-        subpart = build_subpart('8675', etree.fromstring(xml))
+        subpart = reg_text.build_subpart('8675', etree.fromstring(xml))
         self.assertEqual(subpart.node_type, 'subpart')
         self.assertEqual(len(subpart.children), 2)
         self.assertEqual(subpart.label, ['8675', 'Subpart', 'A'])
@@ -317,7 +320,7 @@ class RegTextTest(TestCase):
 
     def test_get_markers(self):
         text = u'(a) <E T="03">Transfer </E>—(1) <E T="03">Notice.</E> follow'
-        markers = get_markers(text)
+        markers = reg_text.get_markers(text)
         self.assertEqual(markers, [u'a', u'1'])
 
     def test_get_markers_and_text(self):
@@ -325,8 +328,8 @@ class RegTextTest(TestCase):
         wrap = '<P>%s</P>' % text
 
         doc = etree.fromstring(wrap)
-        markers = get_markers(text)
-        result = get_markers_and_text(doc, markers)
+        markers = reg_text.get_markers(text)
+        result = reg_text.get_markers_and_text(doc, markers)
 
         markers = [r[0] for r in result]
         self.assertEqual(markers, [u'a', u'1'])
@@ -343,8 +346,8 @@ class RegTextTest(TestCase):
     def test_get_markers_and_text_emph(self):
         text = '(A) aaaa. (<E T="03">1</E>) 1111'
         xml = etree.fromstring('<P>%s</P>' % text)
-        markers = get_markers(text)
-        result = get_markers_and_text(xml, markers)
+        markers = reg_text.get_markers(text)
+        result = reg_text.get_markers_and_text(xml, markers)
 
         a, a1 = result
         self.assertEqual(('A', ('(A) aaaa. ', '(A) aaaa. ')), a)
@@ -356,7 +359,7 @@ class RegTextTest(TestCase):
         text += 'paragraphs (a)(2), (a)(4)(iii), (a)(5), (b) through (d), '
         text += '(f), and (g) with respect to something, (i), (j), (l) '
         text += 'through (p), (q)(1), and (r) with respect to something.'
-        self.assertEqual(['vi'], get_markers(text))
+        self.assertEqual(['vi'], reg_text.get_markers(text))
 
     @patch('regparser.tree.xml_parser.reg_text.content')
     def test_preprocess_xml(self, content):
@@ -377,7 +380,7 @@ class RegTextTest(TestCase):
               <GPH DEEP="453" SPAN="2">
                 <GID>EFGH.0123</GID>
               </GPH>""")]
-        preprocess_xml(xml)
+        reg_text.preprocess_xml(xml)
         should_be = etree.fromstring("""
         <CFRGRANULE>
           <PART>
@@ -401,4 +404,4 @@ class RegTextTest(TestCase):
                 <STARS />
                 <P>(xi) More</P>
             </ROOT>""")
-        self.assertEqual('xi', next_marker(xml.getchildren()[0], []))
+        self.assertEqual('xi', reg_text.next_marker(xml.getchildren()[0], []))

--- a/watch_node.py
+++ b/watch_node.py
@@ -1,0 +1,40 @@
+# @todo - this should be combined with build_from.py
+import argparse
+
+
+try:
+    import requests_cache
+    requests_cache.install_cache('fr_cache')
+except ImportError:
+    # If the cache library isn't present, do nothing -- we'll just make full
+    # HTTP requests rather than looking it up from the cache
+    pass
+
+from regparser.builder import tree_and_builder
+from regparser.notice.changes import node_to_dict, pretty_change
+from regparser.tree.struct import find
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Node Watcher")
+    parser.add_argument(
+        'node_label',
+        help='Label for the node you wish to watch. e.g. 1026-5-a')
+    parser.add_argument('filename',
+                        help='XML file containing the regulation')
+    parser.add_argument('title', type=int, help='Title number')
+    args = parser.parse_args()
+
+    initial_tree, builder = tree_and_builder(args.filename, args.title)
+    initial_node = find(initial_tree, args.node_label)
+    if initial_node:
+        print("> " + builder.doc_number)
+        print("\t" + pretty_change(
+            {'action': 'POST', 'node': node_to_dict(initial_node)}))
+
+    # search for label
+    for version, changes in builder.changes_in_sequence():
+        if args.node_label in changes:
+            print("> " + version)
+            for change in changes[args.node_label]:
+                print("\t" + pretty_change(change))


### PR DESCRIPTION
Corresponds to
* https://github.com/18F/regulations-parser/pull/24 - which fixes CFR part finding for more agencies
* https://github.com/18F/regulations-parser/pull/25 - a "watch" script to see how a node changes over time
* https://github.com/18F/regulations-parser/pull/28 - fixes a bug where diff processing could _not_ be turned off