### PR TITLE
Allow terms in both marked and unmarked paragraphs

### DIFF
--- a/regparser/grammar/terms.py
+++ b/regparser/grammar/terms.py
@@ -1,7 +1,7 @@
 #vim: set encoding=utf-8
 from pyparsing import (
     LineStart, Literal, OneOrMore, Optional, Regex, SkipTo, srange, Suppress,
-    Word, ZeroOrMore)
+    Word, ZeroOrMore, NotAny)
 
 from regparser.grammar import atomic, unified
 from regparser.grammar.utils import DocLiteral, keep_pos, Marker
@@ -16,6 +16,7 @@ smart_quotes = (
 
 e_tag = (
     Suppress(Regex(r"<E[^>]*>"))
+    + NotAny(Marker("this") + Marker("term")) 
     + OneOrMore(
         Word(srange("[a-zA-Z-]"))
     ).setParseAction(keep_pos).setResultsName("term")

--- a/regparser/grammar/terms.py
+++ b/regparser/grammar/terms.py
@@ -24,7 +24,7 @@ e_tag = (
 
 xml_term_parser = (
     LineStart()
-    + Suppress(unified.any_depth_p)
+    + Optional(Suppress(unified.any_depth_p))
     + e_tag.setResultsName("head")
     + ZeroOrMore(
         (atomic.conj_phrases + e_tag).setResultsName(

--- a/regparser/grammar/terms.py
+++ b/regparser/grammar/terms.py
@@ -16,7 +16,6 @@ smart_quotes = (
 
 e_tag = (
     Suppress(Regex(r"<E[^>]*>"))
-    + NotAny(Marker("this") + Marker("term")) 
     + OneOrMore(
         Word(srange("[a-zA-Z-]"))
     ).setParseAction(keep_pos).setResultsName("term")

--- a/tests/grammar_terms_tests.py
+++ b/tests/grammar_terms_tests.py
@@ -1,0 +1,30 @@
+#vim: set encoding=utf-8
+from unittest import TestCase
+
+from regparser.grammar.terms import *
+
+def parse_text(text):
+    return [m[0] for m, _, _ in token_patterns.scanString(text)]
+
+class GrammarTermsTests(TestCase):
+
+    def test_xml_term_parser(self):
+        text = u'(1) <E T="03">Damages incurred</E> means actual damages incurred'
+        result = [match for match, _, _ in xml_term_parser.scanString(text)]
+        match = result[0]
+        self.assertEqual(len(result), 1)
+        self.assertEqual(match.term[0], 'Damages')
+        self.assertEqual(match.term[1], 'incurred')
+
+        text = u'<E T="03">Damages incurred</E> means actual damages incurred'
+        result = [match for match, _, _ in xml_term_parser.scanString(text)]
+        match = result[0]
+        self.assertEqual(len(result), 1)
+        self.assertEqual(match.term[0], 'Damages')
+        self.assertEqual(match.term[1], 'incurred')
+
+        # This sort of text shouldn't match.
+        text = u"This sort of text shouldn't match."
+        result = [match for match, _, _ in xml_term_parser.scanString(text)]
+        self.assertEqual(len(result), 0)
+

--- a/tests/layer_terms_tests.py
+++ b/tests/layer_terms_tests.py
@@ -123,9 +123,7 @@ class LayerTermTest(TestCase):
 
         xml_no_defs = [
             (u'(d) Term1 or term2 means stuff',
-             u'(d) <E T="03">Term1</E> or <E T="03">term2></E> means stuff'),
-            (u'This term means should not match',
-             u'<E T="03">This term</E> means should not match')]
+             u'(d) <E T="03">Term1</E> or <E T="03">term2></E> means stuff'),]
 
         scope_term_defs = [
             ('For purposes of this section, the term blue means the color',


### PR DESCRIPTION
This PR makes the depth indicator based on marked paragraph optional for defined terms. Regulation K has two terms that are defined in unmarked paragraphs that were not being detected as terms. 

This PR also adds a quick test for the terms grammar, since a test case didn't exist. It's only covers the `xml_term_parser`, though.  

@grapesmoker, this may be useful for the definitions in X as well.

@cmc333333, if you could take a look at let me know if this will break anything else, that would be great. I didn't see any changes to the JSON for others regs I ran through with this change. 