### PR TITLE
Add configuration to ignore subheaders in Appendixes

### DIFF
--- a/regparser/tree/xml_parser/appendices.py
+++ b/regparser/tree/xml_parser/appendices.py
@@ -20,7 +20,7 @@ from regparser.tree.xml_parser import tree_utils
 from regparser.tree.xml_parser.interpretations import build_supplement_tree
 from regparser.tree.xml_parser.interpretations import get_app_title
 
-from local_settings import APPENDIX_IGNORE_SUBHEADER_LABEL
+from settings import APPENDIX_IGNORE_SUBHEADER_LABEL
 
 def remove_toc(appendix, letter):
     """The TOC at the top of certain appendices gives us trouble since it

--- a/regparser/tree/xml_parser/appendices.py
+++ b/regparser/tree/xml_parser/appendices.py
@@ -367,7 +367,7 @@ def title_label_pair(text, appendix_letter, reg_part):
                             pair[0], appendix_letter)
             pair = None
 
-    return None
+    return pair
 
 def initial_marker(text):
     parser = (grammar.paren_upper | grammar.paren_lower | grammar.paren_digit

--- a/settings.py
+++ b/settings.py
@@ -87,6 +87,13 @@ REGPATCHES_SOURCES = [
 # versions of their XML
 LOCAL_XML_PATHS = []
 
+
+# Sometimes appendices provide examples or model forms that include
+# labels that we would otherwise recognize as structural to the appendix
+# text itself. This specifies those labels to ignore by regulation
+# number, appendix, and label.
+APPENDIX_IGNORE_SUBHEADER_LABEL = {}
+
 try:
     from local_settings import *
 except ImportError:

--- a/tests/tree_xml_parser_appendices_tests.py
+++ b/tests/tree_xml_parser_appendices_tests.py
@@ -378,24 +378,24 @@ class AppendicesTest(TestCase):
 
     def test_title_label_pair(self):
         title = u'A-1—Model Clauses'
-        self.assertEqual(('1', 2), appendices.title_label_pair(title, 'A'))
+        self.assertEqual(('1', 2), appendices.title_label_pair(title, 'A', '1000'))
 
         title = u'Part III—Construction Period'
-        self.assertEqual(('III', 2), appendices.title_label_pair(title, 'A'))
+        self.assertEqual(('III', 2), appendices.title_label_pair(title, 'A', '1000'))
 
     def test_title_label_pair_parens(self):
         title = u'G-13(A)—Has No parent'
-        self.assertEqual(('13(A)', 2), appendices.title_label_pair(title, 'G'))
+        self.assertEqual(('13(A)', 2), appendices.title_label_pair(title, 'G', '1000'))
 
         title = u'G-13(C)(1) - Some Title'
         self.assertEqual(('13(C)(1)', 2),
-                         appendices.title_label_pair(title, 'G'))
+                         appendices.title_label_pair(title, 'G', '1000'))
 
         title = u'G-13A - Some Title'
-        self.assertEqual(('13A', 2), appendices.title_label_pair(title, 'G'))
+        self.assertEqual(('13A', 2), appendices.title_label_pair(title, 'G', '1000'))
 
         title = u'G-13And Some Smashed Text'
-        self.assertEqual(('13', 2), appendices.title_label_pair(title, 'G'))
+        self.assertEqual(('13', 2), appendices.title_label_pair(title, 'G', '1000'))
 
 
 class AppendixProcessorTest(TestCase):


### PR DESCRIPTION
CFPB Regulation B has, in Appendix C, model forms that have within them subheaders that contain the strings 'Part I' and 'Part II'. These are "parts" of the model form, however, not the appendix itself. This adds configuration that will ignore a given subheader's label for structural purposes.

For example, given the following XML (directly from Reg B):

```xml
<HD SOURCE="HD1">Part I—Principal Reason(s) for Credit Denial, Termination, or Other Action Taken Concerning Credit</HD>
```

This configuration:

```python
APPENDIX_IGNORE_SUBHEADER_LABEL_1002 = {
    'C': ['I', 'II',],
}

APPENDIX_IGNORE_SUBHEADER_LABEL = {
    '1002': APPENDIX_IGNORE_SUBHEADER_LABEL_1002,
}
```

Will cause the parser to treat that XML node as an other header that did not contain 'Part I' in its text.

Possible concerns: It might be helpful to find a way to refer more specifically to particular node. Currently this would catch multiple `I` or `II` labels in appendix `C` if such exist.