### PR TITLE
Grammar/Terms Modifications

### DIFF
--- a/regparser/grammar/atomic.py
+++ b/regparser/grammar/atomic.py
@@ -2,14 +2,14 @@
 """Atomic components; probably shouldn't use these directly"""
 import string
 
-from pyparsing import CaselessLiteral, Optional, Regex, Suppress, Word
+from pyparsing import CaselessLiteral, Optional, Regex, Suppress, Word, OneOrMore
 
 from regparser.grammar.utils import Marker, SuffixMarker, WordBoundaries
 
 
 lower_p = (
     Suppress("(")
-    + Word(string.ascii_lowercase, max=1).setResultsName("p1")
+    + Word(string.ascii_lowercase, max=2).setResultsName("p1")
     + Suppress(")"))
 digit_p = (
     Suppress("(")

--- a/regparser/grammar/terms.py
+++ b/regparser/grammar/terms.py
@@ -29,6 +29,7 @@ xml_term_parser = (
     + ZeroOrMore(
         (atomic.conj_phrases + e_tag).setResultsName(
             "tail", listAllMatches=True))
+    + Suppress(ZeroOrMore(Regex(r",[a-zA-Z ]+,")))
     + ((Marker("mean") | Marker("means"))
        | (Marker("refers") + ZeroOrMore(Marker("only")) + Marker("to"))
        | ((Marker("has") | Marker("have")) + Marker("the") + Marker("same")

--- a/regparser/grammar/terms.py
+++ b/regparser/grammar/terms.py
@@ -30,6 +30,7 @@ xml_term_parser = (
         (atomic.conj_phrases + e_tag).setResultsName(
             "tail", listAllMatches=True))
     + ((Marker("mean") | Marker("means"))
+       | (Marker("refers") + ZeroOrMore(Marker("only")) + Marker("to"))
        | ((Marker("has") | Marker("have")) + Marker("the") + Marker("same")
           + Marker("meaning") + Marker("as")))
 )

--- a/regparser/grammar/terms.py
+++ b/regparser/grammar/terms.py
@@ -26,10 +26,13 @@ xml_term_parser = (
     LineStart()
     + Suppress(unified.any_depth_p)
     + e_tag.setResultsName("head")
+    + Suppress(ZeroOrMore(unified.any_depth_p))
     + ZeroOrMore(
         (atomic.conj_phrases + e_tag).setResultsName(
             "tail", listAllMatches=True))
     + Suppress(ZeroOrMore(Regex(r",[a-zA-Z ]+,")))
+    + Suppress(ZeroOrMore(
+        (Marker("this") | Marker("the")) + Marker("term")))
     + ((Marker("mean") | Marker("means"))
        | (Marker("refers") + ZeroOrMore(Marker("only")) + Marker("to"))
        | ((Marker("has") | Marker("have")) + Marker("the") + Marker("same")

--- a/regparser/grammar/unified.py
+++ b/regparser/grammar/unified.py
@@ -190,3 +190,14 @@ multiple_cfr_p = (
            + atomic.section
            + Optional(depth1_p)).setParseAction(keep_pos).setResultsName(
                "tail", listAllMatches=True)))
+
+notice_cfr_p = (
+    Suppress(atomic.title)
+    + Suppress("CFR")
+    + Suppress(atomic.part_marker | atomic.parts_marker)
+    + OneOrMore(
+        atomic.part
+        + Optional(Suppress(','))
+        + Optional(Suppress('and'))
+    )
+)

--- a/regparser/layer/terms.py
+++ b/regparser/layer/terms.py
@@ -209,6 +209,14 @@ class Terms(Layer):
             else:
                 included_defs.append(Ref(term, n.label_id(), pos))
 
+        cfr_part = node.label[0]
+        if settings.INCLUDE_DEFINITIONS_IN.get(cfr_part):
+            for included_term in settings.INCLUDE_DEFINITIONS_IN[cfr_part]:
+                if included_term in node.text:
+                    pos_start = node.text.index(included_term)
+                    add_match(node, included_term.lower(), 
+                            (pos_start, pos_start + len(included_term)))
+
         if stack and self.has_parent_definitions_indicator(stack):
             for match, _, _ in grammar.smart_quotes.scanString(node.text):
                 term = match.term.tokens[0].lower().strip(',.;')
@@ -283,6 +291,10 @@ class Terms(Layer):
         exclusions = self.per_regulation_ignores(
             exclusions, node.label, node.text)
 
+        inclusions = self.included_offsets(node.label_id(), node.text)
+        inclusions = self.per_regulation_includes(
+                inclusions, node.label, node.text)
+
         matches = self.calculate_offsets(node.text, term_list, exclusions)
         for term, ref, offsets in matches:
             layer_el.append({
@@ -314,12 +326,34 @@ class Terms(Layer):
                 re.finditer(r'\b' + re.escape(ignore_term) + r'\b', text))
         return exclusions
 
-    def calculate_offsets(self, text, applicable_terms, exclusions=[]):
+    def per_regulation_includes(self, inclusions, label, text):
+        cfr_part = label[0]
+        if settings.INCLUDE_DEFINITIONS_IN.get(cfr_part):
+            for include_term in settings.INCLUDE_DEFINITIONS_IN[cfr_part]:
+                inclusions.extend(
+                    (match.start(), match.end()) for match in
+                    re.finditer(r'\b' + re.escape(include_term) + r'\b', text))
+        return inclusions
+
+    def included_offsets(self, label, text):
+        """ We explicitly include certain chunks of text (for example,
+            words that the parser doesn't necessarily pick up as being
+            defined) that should be part of a defined term """
+        inclusions = []
+        for include_term in settings.INCLUDE_DEFINITIONS_IN['ALL']:
+            inclusions.extend(
+                (match.start(), match.end()) for match in
+                re.finditer(r'\b' + re.escape(include_term) + r'\b', text))
+        return inclusions
+
+    def calculate_offsets(self, text, applicable_terms, exclusions=[],
+            inclusions=[]):
         """Search for defined terms in this text, with a preference for all
         larger (i.e. containing) terms."""
 
         # don't modify the original
         exclusions = list(exclusions)
+        inclusions = list(inclusions)
 
         # add plurals to applicable terms
         pluralized = [(pluralize(t[0]), t[1]) for t in applicable_terms]

--- a/regparser/notice/build.py
+++ b/regparser/notice/build.py
@@ -59,11 +59,9 @@ def build_notice(cfr_title, cfr_part, fr_notice, do_process_xml=True):
             fr_notice['full_text_xml_url'])
 
         if len(local_notices) > 0:
-            print "using local notices for %s" % local_notices
             logging.info("using local notices for %s", local_notices)
             return process_local_notices(local_notices, notice, cfr_part)
         else:
-            print "fetching notice %s" % fr_notice['full_text_xml_url']
             logging.info("fetching notice %s", fr_notice['full_text_xml_url'])
             notice_str = requests.get(fr_notice['full_text_xml_url']).content
             return [process_notice(notice, notice_str)]
@@ -359,7 +357,6 @@ def fetch_cfr_parts(notice_xml):
         may not be included in each date. """
     cfr_elm = notice_xml.xpath('//CFR')[0]
     results = notice_cfr_p.parseString(cfr_elm.text)
-    print "notice applies to", list(results)
     return list(results)
 
 def process_xml(notice, notice_xml):

--- a/regparser/notice/build.py
+++ b/regparser/notice/build.py
@@ -93,7 +93,6 @@ def process_local_notices(local_notices, partial_notice, cfr_part):
     for local_notice_file in local_notices:
         with open(local_notice_file, 'r') as f:
             notice = process_notice(partial_notice, f.read())
-            import pdb; pdb.set_trace()
             notices.append(notice)
 
     notices = set_document_numbers(notices)

--- a/regparser/notice/build.py
+++ b/regparser/notice/build.py
@@ -3,6 +3,8 @@ from collections import defaultdict
 import os
 from urlparse import urlparse
 
+import logging 
+
 from lxml import etree
 import requests
 
@@ -19,6 +21,8 @@ from regparser.notice.util import spaces_then_remove, swap_emphasis_tags
 from regparser.notice import changes
 from regparser.tree import struct
 from regparser.tree.xml_parser import reg_text
+from regparser.grammar.unified import notice_cfr_p
+
 import settings
 
 
@@ -49,13 +53,18 @@ def build_notice(cfr_title, cfr_part, fr_notice, do_process_xml=True):
     for key in ('dates', 'end_page', 'start_page', 'type'):
         notice['meta'][key] = fr_notice[key]
 
+    logging.info("need to fetch notice %s?", fr_notice['full_text_xml_url'])
     if fr_notice['full_text_xml_url'] and do_process_xml:
         local_notices = _check_local_version_list(
             fr_notice['full_text_xml_url'])
 
         if len(local_notices) > 0:
-            return process_local_notices(local_notices, notice)
+            print "using local notices for %s" % local_notices
+            logging.info("using local notices for %s", local_notices)
+            return process_local_notices(local_notices, notice, cfr_part)
         else:
+            print "fetching notice %s" % fr_notice['full_text_xml_url']
+            logging.info("fetching notice %s", fr_notice['full_text_xml_url'])
             notice_str = requests.get(fr_notice['full_text_xml_url']).content
             return [process_notice(notice, notice_str)]
     return [notice]
@@ -68,7 +77,7 @@ def split_doc_num(doc_num, effective_date):
     return '%s_%s' % (doc_num, effective_date)
 
 
-def process_local_notices(local_notices, partial_notice):
+def process_local_notices(local_notices, partial_notice, cfr_part):
     """ If we have any local notices, process them. Note that this takes into
     account split notices (a single notice split into two because of different
     effective dates"""
@@ -76,12 +85,15 @@ def process_local_notices(local_notices, partial_notice):
     notices = []
 
     if len(local_notices) > 1:
-        #If the notice is split, pick up the effective date from the XML
+        # If the notice is split, pick up the effective date and the
+        # CFR parts from the XML
         partial_notice['effective_on'] = None
+        partial_notice['cfr_parts'] = None
 
     for local_notice_file in local_notices:
         with open(local_notice_file, 'r') as f:
             notice = process_notice(partial_notice, f.read())
+            import pdb; pdb.set_trace()
             notices.append(notice)
 
     notices = set_document_numbers(notices)
@@ -341,6 +353,16 @@ def process_sxs(notice, notice_xml):
     notice['section_by_section'] = sxs
 
 
+def fetch_cfr_parts(notice_xml):
+    """ Sometimes we need to read the CFR part numbers from the notice
+        XML itself. This would need to happen when we've broken up a
+        multiple-effective-date notice that has multiple CFR parts that
+        may not be included in each date. """
+    cfr_elm = notice_xml.xpath('//CFR')[0]
+    results = notice_cfr_p.parseString(cfr_elm.text)
+    print "notice applies to", list(results)
+    return list(results)
+
 def process_xml(notice, notice_xml):
     """Pull out relevant fields from the xml and add them to the notice"""
 
@@ -356,6 +378,10 @@ def process_xml(notice, notice_xml):
         dates = fetch_dates(notice_xml)
         if dates and 'effective' in dates:
             notice['effective_on'] = dates['effective'][0]
+
+    if not notice.get('cfr_parts'):
+        cfr_parts = fetch_cfr_parts(notice_xml)
+        notice['cfr_parts'] = cfr_parts
 
     process_sxs(notice, notice_xml)
     process_amendments(notice, notice_xml)

--- a/regparser/notice/build.py
+++ b/regparser/notice/build.py
@@ -53,16 +53,15 @@ def build_notice(cfr_title, cfr_part, fr_notice, do_process_xml=True):
     for key in ('dates', 'end_page', 'start_page', 'type'):
         notice['meta'][key] = fr_notice[key]
 
-    logging.info("need to fetch notice %s?", fr_notice['full_text_xml_url'])
     if fr_notice['full_text_xml_url'] and do_process_xml:
         local_notices = _check_local_version_list(
             fr_notice['full_text_xml_url'])
 
         if len(local_notices) > 0:
-            logging.info("using local notices for %s", local_notices)
+            logging.warning("using local xml for %s", fr_notice['full_text_xml_url'])
             return process_local_notices(local_notices, notice, cfr_part)
         else:
-            logging.info("fetching notice %s", fr_notice['full_text_xml_url'])
+            logging.warning("fetching notice %s", fr_notice['full_text_xml_url'])
             notice_str = requests.get(fr_notice['full_text_xml_url']).content
             return [process_notice(notice, notice_str)]
     return [notice]

--- a/regparser/tree/depth/markers.py
+++ b/regparser/tree/depth/markers.py
@@ -6,8 +6,10 @@ import string
 from regparser.utils import roman_nums
 
 
-lower = tuple(string.ascii_lowercase)
-upper = tuple(string.ascii_uppercase)
+lower = tuple(string.ascii_lowercase) + \
+        tuple(a+a for a in string.ascii_lowercase)
+upper = tuple(string.ascii_uppercase) + \
+        tuple(a+a for a in string.ascii_uppercase)
 ints = tuple(str(i) for i in range(1, 51))
 roman = tuple(itertools.islice(roman_nums(), 0, 50))
 em_ints = tuple('<E T="03">' + i + '</E>' for i in ints)

--- a/settings.py
+++ b/settings.py
@@ -64,6 +64,9 @@ DEFAULT_IMAGE_URL = (
 # list of strings: phrases which shouldn't be broken by definition links
 IGNORE_DEFINITIONS_IN = {'ALL':[]}
 
+# List of strings: phrases which should be included as definition links
+INCLUDE_DEFINITIONS_IN = {'ALL':[]}
+
 # list of modules implementing the __contains__ and __getitem__ methods
 OVERRIDES_SOURCES = [
     'regcontent.overrides'

--- a/tests/grammar_amdpar_tests.py
+++ b/tests/grammar_amdpar_tests.py
@@ -490,3 +490,13 @@ class GrammarAmdParTests(TestCase):
             tokens.Verb(tokens.Verb.POST, active=False, and_prefix=False),
             tokens.Context([None, 'Subpart:C'], certain=True)
         ])
+
+    def test_example36(self):
+        text = u'In Appendix A to Part 1002 revise [label:1002-A-p1-2-d] to read:'
+        result = parse_text(text)
+        self.assertEqual(result, [
+            tokens.Context(['1002', 'Appendix:A'], certain=True),
+            tokens.Verb(tokens.Verb.PUT, active=True, and_prefix=False),
+            tokens.Paragraph([ '1002', 'Appendix:A', 'p1', '2', 'd' ], field = None )
+        ])
+        

--- a/tests/grammar_unified_tests.py
+++ b/tests/grammar_unified_tests.py
@@ -13,3 +13,15 @@ class GrammarCommonTests(TestCase):
         self.assertEqual('ii', result.p3)
         self.assertEqual('A', result.p4)
         self.assertEqual('2', result.p5)
+
+    def test_notice_cfr_p(self):
+        text = '12 CFR Parts 1002, 1024, and 1026'
+        result = notice_cfr_p.parseString(text)
+        self.assertEqual(['1002', '1024', '1026'], list(result))
+        text = '12 CFR Parts 1024, and 1026'
+        result = notice_cfr_p.parseString(text)
+        self.assertEqual(['1024', '1026'], list(result))
+        text = '12 CFR Parts 1024'
+        result = notice_cfr_p.parseString(text)
+        self.assertEqual(['1024'], list(result))
+

--- a/tests/layer_terms_tests.py
+++ b/tests/layer_terms_tests.py
@@ -124,7 +124,7 @@ class LayerTermTest(TestCase):
                     u'(v) <E T="03">Lawyers</E>, in relation to coders, means something very different',
                     Ref(u'lawyers', '', (4, 11))),
                 (u'(c) Regulation (1) The term means: ',
-                    u'(c) <E T="03">Regulation</E> (1) The term means:',
+                    u'(c) <E T="03">Regulation</E> (1) The term means: ',
                     Ref(u'regulation', '', (4, 14))),
             ]
 
@@ -193,7 +193,6 @@ class LayerTermTest(TestCase):
             defs, exc = t.node_definitions(node, stack)
             self.assertEqual([ref], defs)
             self.assertEqual([], exc)
-
 
     def test_node_defintions_act(self):
         t = Terms(None)

--- a/tests/layer_terms_tests.py
+++ b/tests/layer_terms_tests.py
@@ -102,24 +102,31 @@ class LayerTermTest(TestCase):
             u'the next one does']
 
         xml_defs = [
-            (u'(4) Thing means a thing that is defined',
-             u'(4) <E T="03">Thing</E> means a thing that is defined',
-             Ref('thing', 'eee', (4, 9))),
-            (u'(e) Well-meaning lawyers means people who do weird things',
-             u'(e) <E T="03">Well-meaning lawyers</E> means people who do '
-             + 'weird things',
-             Ref('well-meaning lawyers', 'fff', (4, 24))),
-            (u'(e) Words have the same meaning as in a dictionary',
-             u'(e) <E T="03">Words</E> have the same meaning as in a '
-             + 'dictionary',
-             Ref('words', 'ffg', (4, 9))),
-            (u'(e) Banana has the same meaning as bonono',
-             u'(e) <E T="03">Banana</E> has the same meaning as bonono',
-             Ref('banana', 'fgf', (4, 10))),
-            (u'(f) Huge billowy clouds means I want to take a nap',
-             u'(f) <E T="03">Huge billowy clouds</E> means I want to take a '
-             + 'nap',
-             Ref('huge billowy clouds', 'ggg', (4, 23)))]
+                (u'(4) Thing means a thing that is defined',
+                    u'(4) <E T="03">Thing</E> means a thing that is defined',
+                    Ref('thing', 'eee', (4, 9))),
+                (u'(e) Well-meaning lawyers means people who do weird things',
+                    u'(e) <E T="03">Well-meaning lawyers</E> means people who do '
+                    + 'weird things',
+                    Ref('well-meaning lawyers', 'fff', (4, 24))),
+                (u'(e) Words have the same meaning as in a dictionary',
+                    u'(e) <E T="03">Words</E> have the same meaning as in a '
+                    + 'dictionary',
+                    Ref('words', 'ffg', (4, 9))),
+                (u'(e) Banana has the same meaning as bonono',
+                    u'(e) <E T="03">Banana</E> has the same meaning as bonono',
+                    Ref('banana', 'fgf', (4, 10))),
+                (u'(f) Huge billowy clouds means I want to take a nap',
+                    u'(f) <E T="03">Huge billowy clouds</E> means I want to take a '
+                    + 'nap',
+                    Ref('huge billowy clouds', 'ggg', (4, 23))),
+                (u'(v) Lawyers, in relation to coders, means something very different',
+                    u'(v) <E T="03">Lawyers</E>, in relation to coders, means something very different',
+                    Ref(u'lawyers', '', (4, 11))),
+                (u'(c) Regulation (1) The term means: ',
+                    u'(c) <E T="03">Regulation</E> (1) The term means:',
+                    Ref(u'regulation', '', (4, 14))),
+            ]
 
         xml_no_defs = [
             (u'(d) Term1 or term2 means stuff',
@@ -186,6 +193,7 @@ class LayerTermTest(TestCase):
             defs, exc = t.node_definitions(node, stack)
             self.assertEqual([ref], defs)
             self.assertEqual([], exc)
+
 
     def test_node_defintions_act(self):
         t = Terms(None)


### PR DESCRIPTION
This makes a number of small modifications to parser grammar:

1. Allow for explicit label specification within notice `<AMDPAR>` elements, i.e.:

  ```xml
<AMDPAR>2. In Appendix A to part 1002, revise [label:1002-A-p1-2-d] to read as follows</AMDPAR>
```

2. Add "only" to the terms parser to match definitions wherein a term "refers only to" something.

3. Match terms that have superfluous, comma-delineated clauses between the term and its definition.

4. Add some grammar to match terms defined within paragraph hierarchy.

5. Extend hierarchy matching to include double-alphas, (aa), (bb), etc. 

Additionally, it adds an explicit configurable include for definitions, `INCLUDE_DEFINITIONS_IN`, conceptually corresponding to `IGNORE_DEFINITIONS_IN`. This is intended to match possible terms that do not include any textual indication that they are being defined ("TERM means...") within the same paragraph. An example of this is "Adverse action" in CFPB reg B.