### PR TITLE
Add tests for marker_comment from ascott1/appendix-ref

### DIFF
--- a/tests/grammar_unified_tests.py
+++ b/tests/grammar_unified_tests.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from unittest import TestCase
 
 from regparser.grammar.unified import *
@@ -13,3 +14,12 @@ class GrammarCommonTests(TestCase):
         self.assertEqual('ii', result.p3)
         self.assertEqual('A', result.p4)
         self.assertEqual('2', result.p5)
+
+    def test_marker_comment(self):
+        texts = [u'comment § 1004.3-4-i',
+                 u'comment 1004.3-4-i',
+                 u'comment 3-4-i',]
+        for t in texts:
+            result = marker_comment.parseString(t)
+            self.assertEqual("3", result.section)
+            self.assertEqual("4", result.c1)


### PR DESCRIPTION
In my excitement that @ascott1 was writing Python, I merged a PR without tests. This is a small attempt to rectify that.

![](https://cloud.githubusercontent.com/assets/10562538/8682901/82686048-2a3d-11e5-85a9-354e43287f24.jpg)
