### PR TITLE
add auxiliary repos to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ local_settings.py
 
 regulations
 regcontent
+fr-notices
+regulations-stub
+regulations-configs
 
 docs/_build
 *.p


### PR DESCRIPTION
Now that we have repos for regulations-configs, regulations-stub, and fr-notices, let's ignore them so they never accidentally get checked in.