### PR TITLE
Match appendices with a dash in their designation

### DIFF
--- a/regparser/grammar/atomic.py
+++ b/regparser/grammar/atomic.py
@@ -60,7 +60,8 @@ part = Word(string.digits).setResultsName("part")
 
 section = Word(string.digits).setResultsName("section")
 
-appendix = Regex(r"[A-Z]+[0-9]*\b").setResultsName("appendix")
+# Should match Appendices like A, AB, BC-1, D1, etc
+appendix = Regex(r"[A-Z]+-?[0-9]*\b").setResultsName("appendix")
 appendix_digit = Word(string.digits).setResultsName("appendix_digit")
 
 subpart = Word(string.ascii_uppercase).setResultsName("subpart")

--- a/tests/grammar_atomic_tests.py
+++ b/tests/grammar_atomic_tests.py
@@ -20,3 +20,10 @@ class GrammarAtomicTests(TestCase):
             with self.assertRaises(ParseException):
                 lower_p.parseString(text)
 
+    def test_appendix(self):
+        for text, a in [('A', 'A'),
+                ('AB', 'AB'),
+                ('BC-1', 'BC-1'),
+                ('D1', 'D1')]:
+            result = appendix.parseString(text)
+            self.assertEqual(a, result.appendix)


### PR DESCRIPTION
This PR adds a tiny bit of parser grammar to match appendices like "BC-1", and adds a test for the atomic.appendix grammar as a whole.
