### PR TITLE
Fix for appendices with dashes in their letter designations

### DIFF
--- a/regparser/grammar/interpretation_headers.py
+++ b/regparser/grammar/interpretation_headers.py
@@ -1,6 +1,6 @@
 import string
 
-from pyparsing import LineEnd, LineStart, SkipTo
+from pyparsing import LineEnd, LineStart, SkipTo, Regex
 
 from regparser.grammar import atomic, unified
 
@@ -25,10 +25,16 @@ marker_par = (
     + unified.depth1_p
 )
 
-
+# This matches an appendix name in an appendix header. Here we'll match
+# something with a dash in the appendix name (i.e. AA-1) but we'll
+# remove the dash. The effect of this is that, for label purposes only,
+# the appendix becomes known as 'AA1', and therefore we don't have weird
+# label collisions with a node labeled '1' underneath the appendix.
 appendix = (
     atomic.appendix_marker.copy().leaveWhitespace()
-    + (unified.appendix_with_section | atomic.appendix )
+    + Regex(r"[A-Z]+-?[0-9]*\b").setResultsName("appendix").setParseAction(
+                    lambda r: r[0].replace('-', '')
+                ).setResultsName("appendix")
     + SkipTo(LineEnd())
 )
 

--- a/regparser/tree/xml_parser/appendices.py
+++ b/regparser/tree/xml_parser/appendices.py
@@ -68,10 +68,8 @@ class AppendixProcessor(object):
                 logging.warning("Found two appendix headers: %s and %s",
                                 self.appendix_letter, text)
             parsed_header = headers.parseString(text)
-            if parsed_header.appendix_section:
-                self.appendix_letter = parsed_header.appendix + '-' + parsed_header.appendix_section
-            else:
-                self.appendix_letter = parsed_header.appendix
+            self.appendix_letter = parsed_header.appendix
+
         return self.appendix_letter
 
     def hed(self, part, text):
@@ -256,9 +254,6 @@ class AppendixProcessor(object):
             self.nodes = []
 
     def process(self, appendix, part):
-        #TODO: currently this fails the appendix parser test
-        #TODO: there should be a flag to check what sort of appendix we have
-        #TODO: if we have an appendix with headings like "A-1" or not
         self.m_stack = tree_utils.NodeStack()
 
         self.part = part
@@ -281,7 +276,6 @@ class AppendixProcessor(object):
 
         for child in appendix.getchildren():
             text = tree_utils.get_node_text(child, add_spaces=True).strip()
-            # print text
             if ((child.tag == 'HD' and child.attrib['SOURCE'] == 'HED')
                     or child.tag == 'RESERVED'):
                 self.end_group()

--- a/tests/grammar_interpretation_headers_tests.py
+++ b/tests/grammar_interpretation_headers_tests.py
@@ -1,3 +1,4 @@
+#vim: set encoding=utf-8
 from unittest import TestCase
 
 from regparser.grammar.interpretation_headers import *
@@ -29,5 +30,12 @@ class GrammarInterpretationHeadersTest(TestCase):
         self.assertEqual('b', match.p1)
 
     def test_appendix(self):
-        match = parser.parseString("Appendix M - More Info")
-        self.assertEqual('M', match.appendix)
+        for text, a in [
+                ('Appendix BC-1 — More Info', 'BC1'),
+
+                ('Appendix A — More Info', 'A'),
+                ('Appendix AB — More Info', 'AB'),
+                ('Appendix D1 — More Info', 'D1')]:
+            result = parser.parseString(text)
+            self.assertEqual(a, result.appendix)
+        

--- a/tests/tree_xml_parser_appendices_tests.py
+++ b/tests/tree_xml_parser_appendices_tests.py
@@ -645,3 +645,18 @@ class AppendixProcessorTest(TestCase):
         self.assertEqual(0, len(a2.children))
         self.assertEqual(['1111', 'A', 'a', 'p1'], amarkerless.label)
         self.assertEqual(0, len(amarkerless.children))
+
+    def test_appendix_letter_dash(self):
+        xml = u"""
+        <APPENDIX>
+            <EAR>Pt. 1111, App. A</EAR>
+            <HD SOURCE="HED">Appendix AA-1 to Part 1111—Awesome</HD>
+            <P>(a) aaaaaa</P>
+        </APPENDIX>
+        """
+        appendix = self.ap.process(etree.fromstring(xml), 1111)
+        self.assertEqual(['1111', 'AA1'], appendix.label)
+
+        a = appendix.children[0]
+        self.assertEqual(['1111', 'AA1', 'a'], a.label)
+


### PR DESCRIPTION
This should fix appendices like Reg X’s MS-1 and MS-2, which have dashes in their letter designations. 

The fix basically removes the dash from the letters as they’re used for labels. This should avoid duplicate label issues with such appendices.

This change may internal citations to said appendices, that’s an issue that will still need to be resolved.
