### PR TITLE
incorporates changes from will, keeps parser from crashing when parsing X

### DIFF
--- a/regparser/grammar/atomic.py
+++ b/regparser/grammar/atomic.py
@@ -60,7 +60,7 @@ part = Word(string.digits).setResultsName("part")
 
 section = Word(string.digits).setResultsName("section")
 
-appendix = Regex(r"[A-Z]+[0-9]*\b").setResultsName("appendix")
+appendix = Regex(r"[A-Z]+-?[0-9]*\b").setResultsName("appendix")
 appendix_digit = Word(string.digits).setResultsName("appendix_digit")
 
 subpart = Word(string.ascii_uppercase).setResultsName("subpart")

--- a/regparser/grammar/atomic.py
+++ b/regparser/grammar/atomic.py
@@ -60,7 +60,7 @@ part = Word(string.digits).setResultsName("part")
 
 section = Word(string.digits).setResultsName("section")
 
-appendix = Regex(r"[A-Z]+-?[0-9]*\b").setResultsName("appendix")
+appendix = Regex(r"[A-Z]+[0-9]*\b").setResultsName("appendix")
 appendix_digit = Word(string.digits).setResultsName("appendix_digit")
 
 subpart = Word(string.ascii_uppercase).setResultsName("subpart")

--- a/regparser/grammar/interpretation_headers.py
+++ b/regparser/grammar/interpretation_headers.py
@@ -1,6 +1,6 @@
 import string
 
-from pyparsing import LineEnd, LineStart, SkipTo
+from pyparsing import LineEnd, LineStart, SkipTo, Regex
 
 from regparser.grammar import atomic, unified
 
@@ -25,10 +25,16 @@ marker_par = (
     + unified.depth1_p
 )
 
-
+# This matches an appendix name in an appendix header. Here we'll match
+# something with a dash in the appendix name (i.e. AA-1) but we'll
+# remove the dash. The effect of this is that, for label purposes only,
+# the appendix becomes known as 'AA1', and therefore we don't have weird
+# label collisions with a node labeled '1' underneath the appendix.
 appendix = (
     atomic.appendix_marker.copy().leaveWhitespace()
-    + (unified.appendix_with_section | atomic.appendix )
+    + Regex(r"[A-Z]+-?[0-9]*\b").setResultsName("appendix").setParseAction(
+                    lambda r: r[0].replace('-', '')
+                ).setResultsName("appendix")
     + SkipTo(LineEnd())
 )
 

--- a/regparser/tree/struct.py
+++ b/regparser/tree/struct.py
@@ -27,6 +27,7 @@ class Node(object):
         self.title = title or None
         self.node_type = node_type
         self.source_xml = source_xml
+        self.marker = None
 
     def __repr__(self):
         return (("Node( text = %s, children = %s, label = %s, title = %s, "
@@ -47,6 +48,8 @@ class NodeEncoder(JSONEncoder):
             fields = dict(obj.__dict__)
             if obj.title is None:
                 del fields['title']
+            if obj.marker is None:
+                del fields['marker']
             for field in ('tagged_text', 'source_xml', 'child_labels'):
                 if field in fields:
                     del fields[field]

--- a/regparser/tree/xml_parser/appendices.py
+++ b/regparser/tree/xml_parser/appendices.py
@@ -68,10 +68,8 @@ class AppendixProcessor(object):
                 logging.warning("Found two appendix headers: %s and %s",
                                 self.appendix_letter, text)
             parsed_header = headers.parseString(text)
-            if parsed_header.appendix_section:
-                self.appendix_letter = parsed_header.appendix + '-' + parsed_header.appendix_section
-            else:
-                self.appendix_letter = parsed_header.appendix
+            self.appendix_letter = parsed_header.appendix
+
         return self.appendix_letter
 
     def hed(self, part, text):
@@ -256,9 +254,6 @@ class AppendixProcessor(object):
             self.nodes = []
 
     def process(self, appendix, part):
-        #TODO: currently this fails the appendix parser test
-        #TODO: there should be a flag to check what sort of appendix we have
-        #TODO: if we have an appendix with headings like "A-1" or not
         self.m_stack = tree_utils.NodeStack()
 
         self.part = part
@@ -281,7 +276,6 @@ class AppendixProcessor(object):
 
         for child in appendix.getchildren():
             text = tree_utils.get_node_text(child, add_spaces=True).strip()
-            # print text
             if ((child.tag == 'HD' and child.attrib['SOURCE'] == 'HED')
                     or child.tag == 'RESERVED'):
                 self.end_group()

--- a/regparser/tree/xml_parser/appendices.py
+++ b/regparser/tree/xml_parser/appendices.py
@@ -163,19 +163,19 @@ class AppendixProcessor(object):
         for mtext in split_paragraph_text(mtext):
             if keyterm:     # still need the original text
                 mtext = mtext.replace(';'*len(keyterm), keyterm)
-            label_candidate = [initial_marker(mtext)[0]]
-            existing_node = None
-            for node in self.nodes:
-                if node.label == label_candidate:
-                    existing_node = node
-            if existing_node:
-                self.paragraph_counter += 1
-                node = Node(mtext, node_type=Node.APPENDIX,
-                            label=['dup{}'.format(self.paragraph_counter),
-                                   initial_marker(mtext)[0]])
-            else:
-                node = Node(mtext, node_type=Node.APPENDIX,
-                            label=[initial_marker(mtext)[0]])
+            # label_candidate = [initial_marker(mtext)[0]]
+            # existing_node = None
+            # for node in self.nodes:
+            #     if node.label == label_candidate:
+            #         existing_node = node
+            # if existing_node:
+            #     self.paragraph_counter += 1
+            #     node = Node(mtext, node_type=Node.APPENDIX,
+            #                 label=['dup{}'.format(self.paragraph_counter),
+            #                        initial_marker(mtext)[0]])
+            # else:
+            node = Node(mtext, node_type=Node.APPENDIX,
+                        label=[initial_marker(mtext)[0]])
             self.nodes.append(node)
 
     def paragraph_no_marker(self, text):

--- a/regparser/tree/xml_parser/appendices.py
+++ b/regparser/tree/xml_parser/appendices.py
@@ -15,7 +15,7 @@ from regparser.layer.key_terms import KeyTerms
 from regparser.tree.depth import markers
 from regparser.tree.depth.derive import derive_depths
 from regparser.tree.paragraph import p_levels
-from regparser.tree.struct import Node
+from regparser.tree.struct import Node, find
 from regparser.tree.xml_parser import tree_utils
 from regparser.tree.xml_parser.interpretations import build_supplement_tree
 from regparser.tree.xml_parser.interpretations import get_app_title
@@ -163,8 +163,19 @@ class AppendixProcessor(object):
         for mtext in split_paragraph_text(mtext):
             if keyterm:     # still need the original text
                 mtext = mtext.replace(';'*len(keyterm), keyterm)
-            node = Node(mtext, node_type=Node.APPENDIX,
-                        label=[initial_marker(mtext)[0]])
+            label_candidate = [initial_marker(mtext)[0]]
+            existing_node = None
+            for node in self.nodes:
+                if node.label == label_candidate:
+                    existing_node = node
+            if existing_node:
+                self.paragraph_counter += 1
+                node = Node(mtext, node_type=Node.APPENDIX,
+                            label=['dup{}'.format(self.paragraph_counter),
+                                   initial_marker(mtext)[0]])
+            else:
+                node = Node(mtext, node_type=Node.APPENDIX,
+                            label=[initial_marker(mtext)[0]])
             self.nodes.append(node)
 
     def paragraph_no_marker(self, text):
@@ -230,18 +241,21 @@ class AppendixProcessor(object):
                        AppendixProcessor.filler_regex.match(n.label[-1])]
             if markers:
                 results = derive_depths(markers)
-                if not results:
+                if not results or results == []:
                     logging.warning('Could not derive depth from {}'.format(markers))
-                depths = list(reversed(
-                    [a.depth for a in results[0].assignment]))
+                    depths = []
+                else:
+                    depths = list(reversed(
+                        [a.depth for a in results[0].assignment]))
             else:
                 depths = []
             depth_zero = None   # relative for beginning of marker depth
             self.depth += 1
             while nodes:
                 node = nodes.pop()
-                if AppendixProcessor.filler_regex.match(node.label[-1]):
-                    # Not a marker paragraph
+                if AppendixProcessor.filler_regex.match(node.label[-1]) or depths == []:
+                    # Not a marker paragraph, or a marker paragraph that isn't actually
+                    # part of a hierarchy (e.g. Appendix C to 1024, notice 2013-28210)
                     self.m_stack.add(self.depth, node)
                 else:
                     depth = depths.pop()

--- a/regparser/tree/xml_parser/interpretations.py
+++ b/regparser/tree/xml_parser/interpretations.py
@@ -301,8 +301,6 @@ def build_supplement_tree(reg_part, node):
         label=[reg_part, Node.INTERP_MARK],
         title=title)
 
-    print root
-
     return parse_from_xml(root, node.getchildren())
 
 

--- a/regparser/tree/xml_parser/reg_text.py
+++ b/regparser/tree/xml_parser/reg_text.py
@@ -277,7 +277,12 @@ def build_from_section(reg_part, section_xml):
         logging.warning('Using manual depth hierarchy.')
         depths = PARAGRAPH_HIERARCHY[reg_part][section_no_without_marker]
         if len(nodes) == len(depths):
-            for node, depth in zip(nodes, depths):
+            for node, spec in zip(nodes, depths):
+                if isinstance(spec, int):
+                    depth = spec
+                elif isinstance(spec, tuple):
+                    depth, marker = spec
+                    node.marker = marker
                 last = m_stack.peek()
                 node.label = [l.replace('<E T="03">', '').replace('</E>', '')
                                   for l in node.label]

--- a/tests/grammar_interpretation_headers_tests.py
+++ b/tests/grammar_interpretation_headers_tests.py
@@ -1,3 +1,4 @@
+#vim: set encoding=utf-8
 from unittest import TestCase
 
 from regparser.grammar.interpretation_headers import *
@@ -29,5 +30,12 @@ class GrammarInterpretationHeadersTest(TestCase):
         self.assertEqual('b', match.p1)
 
     def test_appendix(self):
-        match = parser.parseString("Appendix M - More Info")
-        self.assertEqual('M', match.appendix)
+        for text, a in [
+                ('Appendix BC-1 — More Info', 'BC1'),
+
+                ('Appendix A — More Info', 'A'),
+                ('Appendix AB — More Info', 'AB'),
+                ('Appendix D1 — More Info', 'D1')]:
+            result = parser.parseString(text)
+            self.assertEqual(a, result.appendix)
+        

--- a/tests/notice_compiler_tests.py
+++ b/tests/notice_compiler_tests.py
@@ -881,7 +881,6 @@ class CompilerTests(TestCase):
 
     def test_compile_regulation_delete_move(self):
         prev_tree = self.tree_with_paragraphs()
-        print prev_tree.label[0]
         changes = {
             '205-2-a': [
                 {'action': 'MOVE', 'destination': ['205', '2', 'b']},
@@ -904,8 +903,6 @@ class CompilerTests(TestCase):
                     return False
 
         new_tree = compiler.compile_regulation(prev_tree, SortedKeysDict())
-
-        print new_tree
 
         s1, s2, s4 = new_tree.children
         self.assertEqual(2, len(s2.children))

--- a/tests/tree_xml_parser_appendices_tests.py
+++ b/tests/tree_xml_parser_appendices_tests.py
@@ -645,3 +645,18 @@ class AppendixProcessorTest(TestCase):
         self.assertEqual(0, len(a2.children))
         self.assertEqual(['1111', 'A', 'a', 'p1'], amarkerless.label)
         self.assertEqual(0, len(amarkerless.children))
+
+    def test_appendix_letter_dash(self):
+        xml = u"""
+        <APPENDIX>
+            <EAR>Pt. 1111, App. A</EAR>
+            <HD SOURCE="HED">Appendix AA-1 to Part 1111—Awesome</HD>
+            <P>(a) aaaaaa</P>
+        </APPENDIX>
+        """
+        appendix = self.ap.process(etree.fromstring(xml), 1111)
+        self.assertEqual(['1111', 'AA1'], appendix.label)
+
+        a = appendix.children[0]
+        self.assertEqual(['1111', 'AA1', 'a'], a.label)
+


### PR DESCRIPTION
This PR merges a bunch of useful changes from Will and also checks for a depth solution in the appendix parser. If there is no solution, just tack the node on rather than crashing.

**WARNING** This PR does not yet produce the correct paragraph hierarchy for Reg X, Appendix C, notice 2013-28210.