### PR TITLE
Eliminate Node->dict conversion

### DIFF
--- a/regparser/notice/changes.py
+++ b/regparser/notice/changes.py
@@ -147,7 +147,7 @@ def match_labels_and_changes(amendments, section_node):
 def format_node(node, amendment):
     """ Format a node into a dict, and add in amendment information. """
     node_as_dict = {
-        'node': node_to_dict(node),
+        'node': node,
         'action': amendment['action'],
     }
 

--- a/regparser/notice/compiler.py
+++ b/regparser/notice/compiler.py
@@ -342,8 +342,8 @@ class RegulationTree(object):
             if existing:
                 logging.warning(
                     'Adding a node that already exists: %s' % node.label_id())
-                print '%s %s' % (existing.text, node.label)
-                print '----'
+                # print '%s %s' % (existing.text, node.label)
+                # print '----'
 
             if ((node.node_type in (Node.APPENDIX, Node.INTERP)
                  and len(node.label) == 2) or node.node_type == Node.SUBPART):
@@ -381,23 +381,23 @@ class RegulationTree(object):
         """ Replace just a node's text. """
 
         node = find(self.tree, label)
-        node.text = change['node']['text']
+        node.text = change['node'].text
 
     def replace_node_title(self, label, change):
         """ Replace just a node's title. """
 
         node = find(self.tree, label)
-        node.title = change['node']['title']
+        node.title = change['node'].title
 
     def replace_node_heading(self, label, change):
         """ A node's heading is it's keyterm. We handle this here, but not
         well, I think. """
         node = find(self.tree, label)
-        node.text = replace_first_sentence(node.text, change['node']['text'])
+        node.text = replace_first_sentence(node.text, change['node'].text)
 
-        if hasattr(node, 'tagged_text') and 'tagged_text' in change['node']:
+        if hasattr(node, 'tagged_text') and change['node'].tagged_text is not None:
             node.tagged_text = replace_first_sentence(
-                node.tagged_text, change['node']['tagged_text'])
+                node.tagged_text, change['node'].tagged_text)
 
     def get_subparts(self):
         """ Get all the subparts and empty parts in the tree.  """
@@ -497,12 +497,12 @@ def one_change(reg, label, change):
     replace_subtree = 'field' not in change
 
     if change['action'] == 'PUT' and replace_subtree:
-        node = dict_to_node(change['node'])
+        node = change['node']
         reg.replace_node_and_subtree(node)
     elif change['action'] == 'PUT' and change['field'] in field_list:
         replace_node_field(reg, label, change)
     elif change['action'] == 'POST':
-        node = dict_to_node(change['node'])
+        node = change['node']
         if 'subpart' in change and len(node.label) == 2:
             reg.add_section(node, change['subpart'])
         else:
@@ -515,7 +515,7 @@ def one_change(reg, label, change):
     elif change['action'] == 'DELETE':
         reg.delete(label)
     elif change['action'] == 'RESERVE':
-        node = dict_to_node(change['node'])
+        node = change['node']
         reg.reserve(label, node)
     else:
         print "%s: %s" % (change['action'], label)
@@ -529,7 +529,7 @@ def _needs_delay(reg, change):
     if action == 'MOVE':
         return reg.contains(change['destination'])
     if action == 'POST':
-        existing = reg.find_node(change['node']['label'])
+        existing = reg.find_node(change['node'].label)
         return existing and not is_reserved_node(existing)
     return False
 

--- a/regparser/tree/xml_parser/appendices.py
+++ b/regparser/tree/xml_parser/appendices.py
@@ -127,7 +127,7 @@ class AppendixProcessor(object):
             label, title_depth = pair
             self.depth = title_depth - 1
             n = Node(node_type=Node.APPENDIX, label=[label],
-                     title=text)
+                     title=text, source_xml=xml_node)
         #   Look through parents to determine which level this should be
         else:
             self.header_count += 1
@@ -374,7 +374,6 @@ def title_label_pair(text, appendix_letter, reg_part):
         elif match.aI:
             pair = (match.aI, 2)
 
-
         if pair is not None and \
                 reg_part in APPENDIX_IGNORE_SUBHEADER_LABEL and \
                 pair[0] in APPENDIX_IGNORE_SUBHEADER_LABEL[reg_part][appendix_letter]:
@@ -394,6 +393,7 @@ def initial_marker(text):
         marker = (match.paren_upper or match.paren_lower or match.paren_digit
                   or match.period_upper or match.period_lower
                   or match.period_digit)
+
         if len(marker) < 3 or all(char in 'ivxlcdm' for char in marker):
             return marker, text[:end]
 

--- a/regparser/tree/xml_parser/appendices.py
+++ b/regparser/tree/xml_parser/appendices.py
@@ -345,7 +345,8 @@ def process_appendix(appendix, part):
 
 
 def parsed_title(text, appendix_letter):
-    digit_str_parser = (Marker(appendix_letter)
+    digit_str_parser = (Optional(Suppress("Appendix"))
+                        + Marker(appendix_letter)
                         + Suppress('-')
                         + grammar.a1.copy().leaveWhitespace()
                         + Optional(grammar.markerless_upper)

--- a/tests/notice_build_tests.py
+++ b/tests/notice_build_tests.py
@@ -245,7 +245,7 @@ class NoticeBuildTest(TestCase):
 
         changes = notice['changes']['105-1-b'][0]
         self.assertEqual(changes['action'], 'PUT')
-        self.assertTrue(changes['node']['text'].startswith(
+        self.assertTrue(changes['node'].text.startswith(
             u'(b) This part carries out.'))
 
     def test_process_amendments_multiple_in_same_parent(self):
@@ -272,11 +272,11 @@ class NoticeBuildTest(TestCase):
 
         changes = notice['changes']['105-1-b'][0]
         self.assertEqual(changes['action'], 'PUT')
-        self.assertEqual(changes['node']['text'].strip(),
+        self.assertEqual(changes['node'].text.strip(),
                          u'(b) This part carries out.')
         changes = notice['changes']['105-1-c'][0]
         self.assertEqual(changes['action'], 'PUT')
-        self.assertTrue(changes['node']['text'].strip(),
+        self.assertTrue(changes['node'].text.strip(),
                         u'(c) More stuff')
 
     def test_process_amendments_restart_new_section(self):
@@ -386,7 +386,7 @@ class NoticeBuildTest(TestCase):
             self.assertEqual(n['action'], 'POST')
 
         self.assertEqual(
-            subpart_changes['105-Subpart-B']['node']['node_type'], 'subpart')
+            subpart_changes['105-Subpart-B']['node'].node_type, 'subpart')
 
     def test_process_amendments_subpart(self):
         xml = self.new_subpart_xml()
@@ -537,7 +537,7 @@ class NoticeBuildTest(TestCase):
 
         reserve = notice_changes.changes['200-2-a'][0]
         self.assertEqual(reserve['action'], 'RESERVE')
-        self.assertEqual(reserve['node']['text'], u'[Reserved]')
+        self.assertEqual(reserve['node'].text, u'[Reserved]')
 
     def test_create_xml_changes_stars(self):
         labels_amended = [Amendment('PUT', '200-2-a')]

--- a/tests/notice_changes_tests.py
+++ b/tests/notice_changes_tests.py
@@ -78,9 +78,8 @@ class ChangesTests(TestCase):
             self.assertTrue(l in amends)
 
         for label, node in amends.items():
-            self.assertEqual(label, '-'.join(node['node']['label']))
+            self.assertEqual(label, '-'.join(node['node'].label))
             self.assertEqual(node['action'], 'POST')
-            self.assertFalse('children' in node['node'])
 
     def test_flatten_tree(self):
         tree = self.build_tree()

--- a/tests/notice_compiler_tests.py
+++ b/tests/notice_compiler_tests.py
@@ -406,7 +406,7 @@ class CompilerTests(TestCase):
     def test_replace_node_text(self):
         root = self.tree_with_paragraphs()
 
-        change = {'node': {'text': 'new text'}}
+        change = {'node': Node(text='new text')}
         reg_tree = compiler.RegulationTree(root)
 
         reg_tree.replace_node_text('205-2-a', change)
@@ -416,7 +416,7 @@ class CompilerTests(TestCase):
     def test_replace_node_title(self):
         root = self.tree_with_paragraphs()
 
-        change = {'node': {'title': 'new title'}}
+        change = {'node': Node(title='new title')}
         reg_tree = compiler.RegulationTree(root)
 
         reg_tree.replace_node_title('205-2-a', change)
@@ -429,7 +429,7 @@ class CompilerTests(TestCase):
         n2a.text = 'Previous keyterm. Remainder.'
         reg_tree = compiler.RegulationTree(root)
 
-        change = {'node': {'text': 'Replaced.'}}
+        change = {'node': Node(text='Replaced.')}
         reg_tree.replace_node_heading('205-2-a', change)
 
         changed_node = find(reg_tree.tree, '205-2-a')
@@ -541,17 +541,17 @@ class CompilerTests(TestCase):
 
         change2a = {
             'action': 'PUT',
-            'node': {
-                'text': 'new text',
-                'label': ['205', '2', 'a'],
-                'node_type': 'regtext'}}
+            'node': Node(
+                text='new text',
+                label=['205', '2', 'a'],
+                node_type=Node.REGTEXT)}
 
         change2a1 = {
             'action': 'PUT',
-            'node': {
-                'text': '2a1 text',
-                'label': ['205', '2', 'a', '1'],
-                'node_type': 'regtext'}}
+            'node': Node(
+                text='2a1 text',
+                label=['205', '2', 'a', '1'],
+                node_type=Node.REGTEXT)}
 
         notice_changes = {
             '205-2-a-1': [change2a1],
@@ -571,10 +571,10 @@ class CompilerTests(TestCase):
         change2a = {
             'action': 'PUT',
             'field': '[text]',
-            'node': {
-                'text': 'new text',
-                'label': ['205', '2', 'a'],
-                'node_type': 'regtext'}}
+            'node': Node(
+                text='new text',
+                label=['205', '2', 'a'],
+                node_type=Node.REGTEXT)}
 
         notice_changes = {'205-2-a': [change2a]}
         reg = compiler.compile_regulation(root, notice_changes)
@@ -585,11 +585,11 @@ class CompilerTests(TestCase):
     def test_compile_reg_keep_root(self):
         root = self.tree_with_paragraphs()
         change2 = {'action': 'KEEP',
-                   'node': {'text': '* * *', 'label': ['205', '2'],
-                            'node_type': 'regtext'}}
+                   'node': Node(text='* * *', label=['205', '2'],
+                            node_type=Node.REGTEXT)}
         change2a = {'action': 'PUT',
-                    'node': {'text': '(a) A Test', 'label': ['205', '2', 'a'],
-                             'node_type': 'regtext'}}
+                    'node': Node(text='(a) A Test', label=['205', '2', 'a'],
+                             node_type=Node.REGTEXT)}
 
         notice_changes = {'205-2': [change2], '205-2-a': [change2a]}
         reg = compiler.compile_regulation(root, notice_changes)
@@ -607,14 +607,14 @@ class CompilerTests(TestCase):
     def test_compile_reg_keep_child(self):
         root = self.tree_with_paragraphs()
         change2 = {'action': 'PUT',
-                   'node': {'text': 'n2n2', 'label': ['205', '2'],
-                            'node_type': 'regtext'}}
+                   'node': Node(text='n2n2', label=['205', '2'],
+                            node_type=Node.REGTEXT)}
         change2a = {'action': 'KEEP',
-                    'node': {'text': '(a) * * *', 'label': ['205', '2', 'a'],
-                             'node_type': 'regtext'}}
+                    'node': Node(text='(a) * * *', label=['205', '2', 'a'],
+                             node_type=Node.REGTEXT)}
         change2b = {'action': 'PUT',
-                    'node': {'text': '(b) A Test', 'label': ['205', '2', 'b'],
-                             'node_type': 'regtext'}}
+                    'node': Node(text='(b) A Test', label=['205', '2', 'b'],
+                             node_type=Node.REGTEXT)}
 
         notice_changes = {'205-2': [change2], '205-2-a': [change2a],
                           '205-2-b': [change2b]}
@@ -631,10 +631,10 @@ class CompilerTests(TestCase):
         root = self.tree_with_paragraphs()
         change2a1 = {
             'action': 'POST',
-            'node': {
-                'text': '2a1 text',
-                'label': ['205', '2', 'a', '1'],
-                'node_type': 'regtext'}}
+            'node': Node(
+                text='2a1 text',
+                label=['205', '2', 'a', '1'],
+                node_type=Node.REGTEXT)}
 
         notice_changes = {'205-2-a-1': [change2a1]}
         reg = compiler.compile_regulation(root, notice_changes)
@@ -655,10 +655,10 @@ class CompilerTests(TestCase):
         change = {
             'action': 'POST',
             'subpart': ['205', 'Subpart', 'B'],
-            'node': {
-                'text': '2 text',
-                'label': ['205', '2'],
-                'node_type': 'regtext'}}
+            'node': Node(
+                text='2 text',
+                label=['205', '2'],
+                node_type=Node.REGTEXT)}
 
         notice_changes = {'205-2': [change]}
         reg = compiler.compile_regulation(root, notice_changes)
@@ -671,10 +671,10 @@ class CompilerTests(TestCase):
         change = {
             'action': 'POST',
             'subpart': ['205', 'Subpart', 'B'],
-            'node': {
-                'text': '2 text',
-                'label': ['205', '2'],
-                'node_type': 'regtext'}}
+            'node': Node(
+                text='2 text',
+                label=['205', '2'],
+                node_type=Node.REGTEXT)}
 
         notice_changes = {'205-2': [change]}
         reg = compiler.compile_regulation(root, notice_changes)
@@ -885,9 +885,9 @@ class CompilerTests(TestCase):
         changes = {
             '205-2-a': [
                 {'action': 'MOVE', 'destination': ['205', '2', 'b']},
-                {'action': 'POST', 'node': {'text': 'aaa',
-                                            'label': ['205', '2', 'a'],
-                                            'node_type': Node.REGTEXT}}],
+                {'action': 'POST', 'node': Node(text='aaa',
+                                            label=['205', '2', 'a'],
+                                            node_type=Node.REGTEXT)}],
             '205-2-b': [{'action': 'DELETE'}]}
 
         class SortedKeysDict(object):

--- a/tests/tree_xml_parser_appendices_tests.py
+++ b/tests/tree_xml_parser_appendices_tests.py
@@ -663,8 +663,3 @@ class AppendixProcessorTest(TestCase):
         a = appendix.children[0]
         self.assertEqual(['1111', 'AA1', 'a'], a.label)
 
-    def test_parsed_title(self):
-
-
-        match = parsed_title(text, appendix_letter)
-    

--- a/tests/tree_xml_parser_appendices_tests.py
+++ b/tests/tree_xml_parser_appendices_tests.py
@@ -384,6 +384,9 @@ class AppendicesTest(TestCase):
         title = u'Part III—Construction Period'
         self.assertEqual(('III', 2), appendices.title_label_pair(title, 'A', '1000'))
 
+        title = u'Appendix DC-3(A) to Part 1000'
+        self.assertEqual(('3(A)', 2), appendices.title_label_pair(title, 'DC', '1000'))
+
     def test_title_label_pair_parens(self):
         title = u'G-13(A)—Has No parent'
         self.assertEqual(('13(A)', 2), appendices.title_label_pair(title, 'G', '1000'))
@@ -660,3 +663,8 @@ class AppendixProcessorTest(TestCase):
         a = appendix.children[0]
         self.assertEqual(['1111', 'AA1', 'a'], a.label)
 
+    def test_parsed_title(self):
+
+
+        match = parsed_title(text, appendix_letter)
+    


### PR DESCRIPTION
This eliminates the Node->dict->Node conversion when generating notice changes.

It also adds an optional “Appendix” to the appendix parser’s matching of subhead titles and labels (because CFPB Reg X has an appendix whose subheaders include the word ‘Appendix’). 