### PR TITLE
Catch uppercase roman numerals

### DIFF
--- a/regparser/tree/xml_parser/appendices.py
+++ b/regparser/tree/xml_parser/appendices.py
@@ -140,7 +140,7 @@ class AppendixProcessor(object):
         self.m_stack.add(self.depth, n)
 
     def insert_dashes(self, xml_node, text):
-        """ If paragraph has a SOURCE attribute with a value of FP-DASH 
+        """ If paragraph has a SOURCE attribute with a value of FP-DASH
             it fills out with dashes, like Foo_____. """
         mtext = text
         if xml_node.get('SOURCE') == 'FP-DASH':
@@ -284,7 +284,7 @@ class AppendixProcessor(object):
         def is_subhead(tag, text):
             initial = initial_marker(text)
             return ((tag == 'HD' and (not initial or '.' in initial[1]))
-                    or (tag in ('P', 'FP') 
+                    or (tag in ('P', 'FP')
                         and title_label_pair(text, self.appendix_letter,
                             self.part)))
 
@@ -386,7 +386,8 @@ def title_label_pair(text, appendix_letter, reg_part):
             pair = (match.a1, 2)
         elif match.aI:
             pair = (match.aI, 2)
-
+        elif match.roman_upper:
+            pair = (match.roman_upper, 2)
 
         if pair is not None and \
                 reg_part in APPENDIX_IGNORE_SUBHEADER_LABEL and \

--- a/regparser/tree/xml_parser/appendices.py
+++ b/regparser/tree/xml_parser/appendices.py
@@ -386,7 +386,7 @@ def title_label_pair(text, appendix_letter, reg_part):
             pair = (match.a1, 2)
         elif match.aI:
             pair = (match.aI, 2)
-        elif match.roman_upper:
+        elif match.roman_upper and reg_part in text:
             pair = (match.roman_upper, 2)
 
         if pair is not None and \

--- a/tests/tree_xml_parser_appendices_tests.py
+++ b/tests/tree_xml_parser_appendices_tests.py
@@ -134,7 +134,7 @@ class AppendicesTest(TestCase):
             <HD SOURCE="HD3">I. Remains Header</HD>
             <P>1. Content tent</P>
         </APPENDIX>"""
-        appendix = appendices.process_appendix(etree.fromstring(xml), 1111)
+        appendix = appendices.process_appendix(etree.fromstring(xml), '1111')
         self.assertEqual(1, len(appendix.children))
         a1 = appendix.children[0]
 
@@ -400,7 +400,7 @@ class AppendicesTest(TestCase):
 
     def test_title_label_pair_roman(self):
         title = u'IX. Sample Page for Statement of Record —1010.102(e)'
-        self.assertEqual(('IX', 2), appendices.title_label_pair(title, 'A', '1000'))
+        self.assertEqual(('IX', 2), appendices.title_label_pair(title, 'A', '1010'))
 
 class AppendixProcessorTest(TestCase):
     def setUp(self):

--- a/tests/tree_xml_parser_appendices_tests.py
+++ b/tests/tree_xml_parser_appendices_tests.py
@@ -398,6 +398,9 @@ class AppendicesTest(TestCase):
         title = u'G-13And Some Smashed Text'
         self.assertEqual(('13', 2), appendices.title_label_pair(title, 'G', '1000'))
 
+    def test_title_label_pair_roman(self):
+        title = u'IX. Sample Page for Statement of Record —1010.102(e)'
+        self.assertEqual(('IX', 2), appendices.title_label_pair(title, 'A', '1000'))
 
 class AppendixProcessorTest(TestCase):
     def setUp(self):
@@ -659,4 +662,3 @@ class AppendixProcessorTest(TestCase):
 
         a = appendix.children[0]
         self.assertEqual(['1111', 'AA1', 'a'], a.label)
-


### PR DESCRIPTION
As originally written by @grapesmoker and transcribed by me. 

Now only picking up titles that contain the reg part.

