### PR TITLE
Fix non-manual markerless

### DIFF
--- a/regparser/default_settings.py
+++ b/regparser/default_settings.py
@@ -108,5 +108,5 @@ REISSUANCES = ['2013-01737', '2012-14047', '2012-14061', '2012-14062']
 
 # It may be necessary to override the 'effective_on', 'dates', etc that
 # are fetched from the Federal Register initially, before the XML is
-# parsed. This is done per-CFR part, per-notice.
-FR_NOTICE_OVERRIDES = {'ALL':[]}
+# parsed. This is done per-notice.
+FR_NOTICE_OVERRIDES = {}

--- a/regparser/default_settings.py
+++ b/regparser/default_settings.py
@@ -105,3 +105,8 @@ PARAGRAPH_HIERARCHY = {'ALL':[]}
 
 # which notices are complete reissuances
 REISSUANCES = ['2013-01737', '2012-14047', '2012-14061', '2012-14062']
+
+# It may be necessary to override the 'effective_on', 'dates', etc that
+# are fetched from the Federal Register initially, before the XML is
+# parsed. This is done per-CFR part, per-notice.
+FR_NOTICE_OVERRIDES = {'ALL':[]}

--- a/regparser/notice/build.py
+++ b/regparser/notice/build.py
@@ -28,12 +28,23 @@ import settings
 
 
 def build_notice(cfr_title, cfr_part, fr_notice, do_process_xml=True):
-    """Given JSON from the federal register, create our notice structure"""
+    """ Given JSON from the federal register, create our notice structure """
     logging.info('building notice, title {0}, part {1}, notice {2}'.format(cfr_title, cfr_part, fr_notice['document_number']))
     cfr_parts = set(str(ref['part']) for ref in fr_notice['cfr_references'])
     cfr_parts.add(cfr_part)
+
     notice = {'cfr_title': cfr_title, 'cfr_parts': list(cfr_parts)}
-    #   Copy over most fields
+    notice_number = fr_notice['document_number']
+
+    # Check for configured overrides of the FR JSON for this notice
+    if cfr_part in settings.FR_NOTICE_OVERRIDES and \
+            notice_number in settings.FR_NOTICE_OVERRIDES[cfr_part]:
+        logging.warning("overriding FR for {}".format(notice_number))
+        notice_overrides = settings.FR_NOTICE_OVERRIDES[cfr_part][notice_number]
+        for k, v in notice_overrides.iteritems():
+            fr_notice[k] = v
+
+    # Copy over most fields
     for field in ['abstract', 'action', 'agency_names', 'comments_close_on',
                   'document_number', 'publication_date',
                   'regulation_id_numbers']:

--- a/regparser/notice/build.py
+++ b/regparser/notice/build.py
@@ -37,10 +37,9 @@ def build_notice(cfr_title, cfr_part, fr_notice, do_process_xml=True):
     notice_number = fr_notice['document_number']
 
     # Check for configured overrides of the FR JSON for this notice
-    if cfr_part in settings.FR_NOTICE_OVERRIDES and \
-            notice_number in settings.FR_NOTICE_OVERRIDES[cfr_part]:
+    if notice_number in settings.FR_NOTICE_OVERRIDES:
         logging.warning("overriding FR for {}".format(notice_number))
-        notice_overrides = settings.FR_NOTICE_OVERRIDES[cfr_part][notice_number]
+        notice_overrides = settings.FR_NOTICE_OVERRIDES[notice_number]
         for k, v in notice_overrides.iteritems():
             fr_notice[k] = v
 

--- a/regparser/notice/changes.py
+++ b/regparser/notice/changes.py
@@ -147,7 +147,7 @@ def match_labels_and_changes(amendments, section_node):
 def format_node(node, amendment):
     """ Format a node into a dict, and add in amendment information. """
     node_as_dict = {
-        'node': node_to_dict(node),
+        'node': node,
         'action': amendment['action'],
     }
 

--- a/regparser/notice/changes.py
+++ b/regparser/notice/changes.py
@@ -6,6 +6,8 @@ import logging
 import copy
 from collections import defaultdict
 
+from lxml import etree
+
 from regparser.grammar.tokens import Verb
 from regparser.layer.paragraph_markers import marker_of
 from regparser.tree import struct
@@ -145,9 +147,20 @@ def match_labels_and_changes(amendments, section_node):
 
 
 def format_node(node, amendment):
-    """ Format a node into a dict, and add in amendment information. """
+    """ Format a node and add in amendment information. """
+    
+    # Copy the node, remove it's children, and dump its XML to string
+    node_no_kids = copy.deepcopy(node)
+    node_no_kids.children = []
+
+    try:
+        node_no_kids.source_xml = etree.tostring(node_no_kids.source_xml)
+    except TypeError:
+        # source_xml wasn't serializable
+        pass
+
     node_as_dict = {
-        'node': node,
+        'node': node_no_kids,
         'action': amendment['action'],
     }
 

--- a/regparser/notice/compiler.py
+++ b/regparser/notice/compiler.py
@@ -498,7 +498,7 @@ def one_change(reg, label, change):
     field_list = ['[text]', '[title]', '[heading]']
     replace_subtree = 'field' not in change
 
-    # Conver the change's node's source_xml to Element in place if needed
+    # Convert the change's node's source_xml to Element in place if needed
     if 'node' in change:
         try:
             change['node'].source_xml = etree.fromstring(

--- a/regparser/notice/compiler.py
+++ b/regparser/notice/compiler.py
@@ -7,6 +7,8 @@ import copy
 import itertools
 import logging
 
+from lxml import etree
+
 from regparser.grammar.tokens import Verb
 from regparser.tree.struct import Node, find, walk
 from regparser.tree.xml_parser import interpretations
@@ -495,6 +497,14 @@ def one_change(reg, label, change):
     single change to the tree."""
     field_list = ['[text]', '[title]', '[heading]']
     replace_subtree = 'field' not in change
+
+    # Conver the change's node's source_xml to Element in place if needed
+    if 'node' in change:
+        try:
+            change['node'].source_xml = etree.fromstring(
+                    change['node'].source_xml)
+        except ValueError:
+            pass
 
     if change['action'] == 'PUT' and replace_subtree:
         node = change['node']

--- a/regparser/notice/compiler.py
+++ b/regparser/notice/compiler.py
@@ -342,8 +342,8 @@ class RegulationTree(object):
             if existing:
                 logging.warning(
                     'Adding a node that already exists: %s' % node.label_id())
-                print '%s %s' % (existing.text, node.label)
-                print '----'
+                # print '%s %s' % (existing.text, node.label)
+                # print '----'
 
             if ((node.node_type in (Node.APPENDIX, Node.INTERP)
                  and len(node.label) == 2) or node.node_type == Node.SUBPART):
@@ -381,23 +381,23 @@ class RegulationTree(object):
         """ Replace just a node's text. """
 
         node = find(self.tree, label)
-        node.text = change['node']['text']
+        node.text = change['node'].text
 
     def replace_node_title(self, label, change):
         """ Replace just a node's title. """
 
         node = find(self.tree, label)
-        node.title = change['node']['title']
+        node.title = change['node'].title
 
     def replace_node_heading(self, label, change):
         """ A node's heading is it's keyterm. We handle this here, but not
         well, I think. """
         node = find(self.tree, label)
-        node.text = replace_first_sentence(node.text, change['node']['text'])
+        node.text = replace_first_sentence(node.text, change['node'].text)
 
-        if hasattr(node, 'tagged_text') and 'tagged_text' in change['node']:
+        if hasattr(node, 'tagged_text') and change['node'].tagged_text is not None:
             node.tagged_text = replace_first_sentence(
-                node.tagged_text, change['node']['tagged_text'])
+                node.tagged_text, change['node'].tagged_text)
 
     def get_subparts(self):
         """ Get all the subparts and empty parts in the tree.  """
@@ -497,12 +497,12 @@ def one_change(reg, label, change):
     replace_subtree = 'field' not in change
 
     if change['action'] == 'PUT' and replace_subtree:
-        node = dict_to_node(change['node'])
+        node = change['node']
         reg.replace_node_and_subtree(node)
     elif change['action'] == 'PUT' and change['field'] in field_list:
         replace_node_field(reg, label, change)
     elif change['action'] == 'POST':
-        node = dict_to_node(change['node'])
+        node = change['node']
         if 'subpart' in change and len(node.label) == 2:
             reg.add_section(node, change['subpart'])
         else:
@@ -515,7 +515,7 @@ def one_change(reg, label, change):
     elif change['action'] == 'DELETE':
         reg.delete(label)
     elif change['action'] == 'RESERVE':
-        node = dict_to_node(change['node'])
+        node = change['node']
         reg.reserve(label, node)
     else:
         print "%s: %s" % (change['action'], label)
@@ -529,7 +529,7 @@ def _needs_delay(reg, change):
     if action == 'MOVE':
         return reg.contains(change['destination'])
     if action == 'POST':
-        existing = reg.find_node(change['node']['label'])
+        existing = reg.find_node(change['node'].label)
         return existing and not is_reserved_node(existing)
     return False
 

--- a/regparser/tree/xml_parser/appendices.py
+++ b/regparser/tree/xml_parser/appendices.py
@@ -127,7 +127,7 @@ class AppendixProcessor(object):
             label, title_depth = pair
             self.depth = title_depth - 1
             n = Node(node_type=Node.APPENDIX, label=[label],
-                     title=text)
+                     title=text, source_xml=xml_node)
         #   Look through parents to determine which level this should be
         else:
             self.header_count += 1
@@ -374,7 +374,6 @@ def title_label_pair(text, appendix_letter, reg_part):
         elif match.aI:
             pair = (match.aI, 2)
 
-
         if pair is not None and \
                 reg_part in APPENDIX_IGNORE_SUBHEADER_LABEL and \
                 pair[0] in APPENDIX_IGNORE_SUBHEADER_LABEL[reg_part][appendix_letter]:
@@ -394,6 +393,7 @@ def initial_marker(text):
         marker = (match.paren_upper or match.paren_lower or match.paren_digit
                   or match.period_upper or match.period_lower
                   or match.period_digit)
+
         if len(marker) < 3 or all(char in 'ivxlcdm' for char in marker):
             return marker, text[:end]
 

--- a/regparser/tree/xml_parser/appendices.py
+++ b/regparser/tree/xml_parser/appendices.py
@@ -140,7 +140,7 @@ class AppendixProcessor(object):
         self.m_stack.add(self.depth, n)
 
     def insert_dashes(self, xml_node, text):
-        """ If paragraph has a SOURCE attribute with a value of FP-DASH 
+        """ If paragraph has a SOURCE attribute with a value of FP-DASH
             it fills out with dashes, like Foo_____. """
         mtext = text
         if xml_node.get('SOURCE') == 'FP-DASH':
@@ -284,7 +284,7 @@ class AppendixProcessor(object):
         def is_subhead(tag, text):
             initial = initial_marker(text)
             return ((tag == 'HD' and (not initial or '.' in initial[1]))
-                    or (tag in ('P', 'FP') 
+                    or (tag in ('P', 'FP')
                         and title_label_pair(text, self.appendix_letter,
                             self.part)))
 
@@ -387,6 +387,8 @@ def title_label_pair(text, appendix_letter, reg_part):
             pair = (match.a1, 2)
         elif match.aI:
             pair = (match.aI, 2)
+        elif match.roman_upper and reg_part in text:
+            pair = (match.roman_upper, 2)
 
         if pair is not None and \
                 reg_part in APPENDIX_IGNORE_SUBHEADER_LABEL and \

--- a/regparser/tree/xml_parser/appendices.py
+++ b/regparser/tree/xml_parser/appendices.py
@@ -345,7 +345,8 @@ def process_appendix(appendix, part):
 
 
 def parsed_title(text, appendix_letter):
-    digit_str_parser = (Marker(appendix_letter)
+    digit_str_parser = (Optional(Suppress("Appendix"))
+                        + Marker(appendix_letter)
                         + Suppress('-')
                         + grammar.a1.copy().leaveWhitespace()
                         + Optional(grammar.markerless_upper)

--- a/regparser/tree/xml_parser/interpretations.py
+++ b/regparser/tree/xml_parser/interpretations.py
@@ -191,7 +191,7 @@ def process_inner_children(inner_stack, xml_node):
         depths = derive_depths(
             [n.label[0] for n in nodes],
             [rules.depth_type_order([(mtypes.ints, mtypes.em_ints),
-                                     (mtypes.roman, mtypes.upper),
+                                     (mtypes.lower, mtypes.roman, mtypes.upper),
                                      mtypes.upper, mtypes.em_ints,
                                      mtypes.em_roman])])
 

--- a/regparser/tree/xml_parser/interpretations.py
+++ b/regparser/tree/xml_parser/interpretations.py
@@ -147,14 +147,25 @@ def process_inner_children(inner_stack, xml_node):
         first_marker = get_first_interp_marker(text_with_tags)
         if xml_node.tag == 'STARS':
             nodes.append(Node(label=[mtypes.STARS_TAG]))
-        elif not first_marker and nodes:
+        elif not first_marker and nodes and manual_hierarchy_flag:
             logging.warning("Couldn't determine interp marker. "
-                            "Appending node and hoping that manual hierarchy is specified")
+                            "Manual hierarchy is specified")
 
             n = Node(node_text, label=[str(i)], node_type=Node.INTERP)
             n.tagged_text = text_with_tags
             nodes.append(n)
 
+        elif not first_marker and nodes and not manual_hierarchy_flag:
+            logging.warning("Couldn't determine interp marker. Appending to "
+                            "previous paragraph: %s", node_text)
+                    
+            previous = nodes[-1]
+            previous.text += "\n\n" + node_text
+            if hasattr(previous, 'tagged_text'):
+                previous.tagged_text += "\n\n" + text_with_tags
+            else:
+                previous.tagged_text = text_with_tags
+            
         else:
             collapsed = collapsed_markers_matches(node_text, text_with_tags)
 

--- a/regparser/tree/xml_parser/reg_text.py
+++ b/regparser/tree/xml_parser/reg_text.py
@@ -224,7 +224,7 @@ def build_from_section(reg_part, section_xml):
                 else:
                     section_texts.append((text, tagged_text))
             else:
-                if len(children) > 1:
+                if len(children) > 1 and children.index(ch) != 0:
                     def_marker = 'def{0}'.format(i)
                     n = Node(text, [], [def_marker], source_xml=ch)
                     n.tagged_text = tagged_text

--- a/regparser/tree/xml_parser/reg_text.py
+++ b/regparser/tree/xml_parser/reg_text.py
@@ -187,10 +187,9 @@ def build_from_section(reg_part, section_xml):
         subject_xml = section_xml.xpath('RESERVED')
     subject_text = subject_xml[0].text
 
-    manual_hierarchy_flag = False
+    manual_hierarchy = []
     if reg_part in PARAGRAPH_HIERARCHY and section_no_without_marker in PARAGRAPH_HIERARCHY[reg_part]:
-        manual_hierarchy_flag = True
-
+        manual_hierarchy = PARAGRAPH_HIERARCHY[reg_part][section_no_without_marker]
 
     # Collect paragraph markers and section text (intro text for the
     # section)
@@ -201,19 +200,31 @@ def build_from_section(reg_part, section_xml):
         tagged_text = tree_utils.get_node_text_tags_preserved(ch)
         markers_list = get_markers(tagged_text.strip())
 
+        # If the child has a 'DEPTH' attribute, we're in manual
+        # hierarchy mode, just constructed from the XML instead of
+        # specified in configuration.
+        # This presumes that every child in the section has DEPTH
+        # specified, if not, things will break in and around 
+        # derive_depths below.
+        if ch.get("depth") is not None:
+            manual_hierarchy.append(int(ch.get("depth")))
+
         if ch.tag == 'STARS':
             nodes.append(Node(label=[mtypes.STARS_TAG]))
-        elif not markers_list and manual_hierarchy_flag:
+        elif not markers_list and manual_hierarchy:
             # is this a bunch of definitions that don't have numbers next to them?
             if len(nodes) > 0:
-                if (subject_text.find('Definitions.') > -1 or nodes[-1].text.find('For the purposes of this section')):
+                if (subject_text.find('Definitions.') > -1 or \
+                        nodes[-1].text.find('For the purposes of this section')):
                     #TODO: create a grammar for definitions
                     if text.find('means') > -1:
                         def_marker = text.split('means')[0].strip().split()
-                        def_marker = ''.join([word[0].upper() + word[1:] for word in def_marker])
+                        def_marker = ''.join([word[0].upper() + word[1:] 
+                            for word in def_marker])
                     elif text.find('shall have the same meaning') > -1:
                         def_marker = text.split('shall')[0].strip().split()
-                        def_marker = ''.join([word[0].upper() + word[1:] for word in def_marker])
+                        def_marker = ''.join([word[0].upper() + word[1:] 
+                            for word in def_marker])
                     else:
                         def_marker = 'def{0}'.format(i)
                         i += 1
@@ -234,7 +245,7 @@ def build_from_section(reg_part, section_xml):
                     # this is the only node around
                     section_texts.append((text, tagged_text))
 
-        elif not markers_list and not manual_hierarchy_flag:
+        elif not markers_list and not manual_hierarchy:
             # No manual heirarchy specified, append to the section.
             section_texts.append((text, tagged_text))
         else:
@@ -253,14 +264,14 @@ def build_from_section(reg_part, section_xml):
     m_stack = tree_utils.NodeStack()
 
     # Use constraint programming to figure out possible depth assignments
-    if not manual_hierarchy_flag:
+    if not manual_hierarchy:
         depths = derive_depths(
             [n.label[0] for n in nodes],
             [rules.depth_type_order([mtypes.lower, mtypes.ints, mtypes.roman,
                                      mtypes.upper, mtypes.em_ints,
                                      mtypes.em_roman])])
 
-    if not manual_hierarchy_flag and depths:
+    if not manual_hierarchy and depths:
         # Find the assignment which violates the least of our heuristics
         depths = heuristics.prefer_multiple_children(depths, 0.5)
         depths = sorted(depths, key=lambda d: d.weight, reverse=True)
@@ -276,9 +287,9 @@ def build_from_section(reg_part, section_xml):
                 else:
                     m_stack.add(1 + par.depth, node)
 
-    elif nodes and manual_hierarchy_flag:
+    elif nodes and manual_hierarchy:
         logging.warning('Using manual depth hierarchy.')
-        depths = PARAGRAPH_HIERARCHY[reg_part][section_no_without_marker]
+        depths = manual_hierarchy
         if len(nodes) == len(depths):
             for node, spec in zip(nodes, depths):
                 if isinstance(spec, int):
@@ -297,7 +308,7 @@ def build_from_section(reg_part, section_xml):
             logging.error('Manual hierarchy length does not match node list length!'
                           ' ({0} nodes but {1} provided)'.format(len(nodes), len(depths)))
 
-    elif nodes and not manual_hierarchy_flag:
+    elif nodes and not manual_hierarchy:
         logging.warning('Could not determine depth when parsing {0}:\n{1}'.format(section_no_without_marker, [n.label[0] for n in nodes]))
         for node in nodes:
             last = m_stack.peek()

--- a/regparser/tree/xml_parser/reg_text.py
+++ b/regparser/tree/xml_parser/reg_text.py
@@ -203,7 +203,7 @@ def build_from_section(reg_part, section_xml):
 
         if ch.tag == 'STARS':
             nodes.append(Node(label=[mtypes.STARS_TAG]))
-        elif not markers_list:
+        elif not markers_list and manual_hierarchy_flag:
             # is this a bunch of definitions that don't have numbers next to them?
             if len(nodes) > 0:
                 if (subject_text.find('Definitions.') > -1 or nodes[-1].text.find('For the purposes of this section')):
@@ -224,7 +224,7 @@ def build_from_section(reg_part, section_xml):
                 else:
                     section_texts.append((text, tagged_text))
             else:
-                if len(children) > 1 and children.index(ch) != 0:
+                if len(children) > 1:
                     def_marker = 'def{0}'.format(i)
                     n = Node(text, [], [def_marker], source_xml=ch)
                     n.tagged_text = tagged_text
@@ -234,6 +234,9 @@ def build_from_section(reg_part, section_xml):
                     # this is the only node around
                     section_texts.append((text, tagged_text))
 
+        elif not markers_list and not manual_hierarchy_flag:
+            # No manual heirarchy specified, append to the section.
+            section_texts.append((text, tagged_text))
         else:
             for m, node_text in get_markers_and_text(ch, markers_list):
                 n = Node(node_text[0], [], [m], source_xml=ch)

--- a/tests/history_delays_tests.py
+++ b/tests/history_delays_tests.py
@@ -59,16 +59,3 @@ class HistoryDelaysTests(TestCase):
         self.assertFalse(overlaps_with(fr, meta(11, 220, 230)))
         self.assertFalse(overlaps_with(fr, meta(10, 226, 230)))
         self.assertFalse(overlaps_with(fr, meta(10, 220, 224)))
-
-    def test_altered_frs(self):
-        sent = "The effective date of 12 FR 501, 13 FR 999, and (13 FR 764) "
-        sent += "has been delayed."
-        self.assertEqual(altered_frs(sent),
-                         ([Notice(12, 501), Notice(13, 999), Notice(13, 764)],
-                          None))
-        sent = "In 11 FR 123 we delayed the effective date"
-        self.assertEqual(altered_frs(sent), ([], None))
-        sent = "The effective date of 9 FR 765 has been delayed until "
-        sent += "January 7, 2008; rather I mean March 4 2008"
-        self.assertEqual(altered_frs(sent),
-                         ([Notice(9, 765)], date(2008, 3, 4)))

--- a/tests/notice_build_tests.py
+++ b/tests/notice_build_tests.py
@@ -67,6 +67,59 @@ class NoticeBuildTest(TestCase):
             'regulation_id_numbers': ['a231a-232q'],
         }])
 
+    def test_build_notice_override_fr(self):
+        """ Test that the FR_NOTICE_OVERRIDES setting can override the
+        'dates' value from build_notice """
+        fr = {
+            'abstract': 'sum sum sum',
+            'action': 'actact',
+            'agency_names': ['Agency 1', 'Agency 2'],
+            'cfr_references': [{'title': 12, 'part': 9191},
+                               {'title': 12, 'part': 9292}],
+            'citation': 'citation citation',
+            'comments_close_on': None,
+            'dates': 'date info',
+            'document_number': '7878-111',
+            'effective_on': '1956-09-09',
+            'end_page': 9999,
+            'full_text_xml_url': None,
+            'html_url': 'some url',
+            'publication_date': '1955-12-10',
+            'regulation_id_numbers': ['a231a-232q'],
+            'start_page': 8888,
+            'type': 'Rule',
+            'volume': 66,
+        }
+
+        # Set our override value
+        build.settings.FR_NOTICE_OVERRIDES['9292'] = {
+            '7878-111': {
+                'dates': 'new date info',
+            },
+        }
+        
+        self.assertEqual(build.build_notice('5', '9292', fr), [{
+            'abstract': 'sum sum sum',
+            'action': 'actact',
+            'agency_names': ['Agency 1', 'Agency 2'],
+            'cfr_parts': ['9191', '9292'],
+            'cfr_title': '5',
+            'document_number': '7878-111',
+            'effective_on': '1956-09-09',
+            'fr_citation': 'citation citation',
+            'fr_url': 'some url',
+            'fr_volume': 66,
+            'initial_effective_on': '1956-09-09',
+            'meta': {
+                'dates': 'new date info',
+                'end_page': 9999,
+                'start_page': 8888,
+                'type': 'Rule'
+            },
+            'publication_date': '1955-12-10',
+            'regulation_id_numbers': ['a231a-232q'],
+        }])
+
     def test_process_xml(self):
         """Integration test for xml processing"""
         xml = """

--- a/tests/notice_build_tests.py
+++ b/tests/notice_build_tests.py
@@ -92,10 +92,8 @@ class NoticeBuildTest(TestCase):
         }
 
         # Set our override value
-        build.settings.FR_NOTICE_OVERRIDES['9292'] = {
-            '7878-111': {
-                'dates': 'new date info',
-            },
+        build.settings.FR_NOTICE_OVERRIDES['7878-111'] = {
+            'dates': 'new date info',
         }
         
         self.assertEqual(build.build_notice('5', '9292', fr), [{

--- a/tests/notice_build_tests.py
+++ b/tests/notice_build_tests.py
@@ -379,7 +379,7 @@ class NoticeBuildTest(TestCase):
         notice = {'cfr_parts': ['105']}
         subpart_changes = build.process_new_subpart(notice, amended_label, par)
 
-        new_nodes_added = ['105-Subpart-B', '105-30', '105-30-def0', '105-30-a']
+        new_nodes_added = ['105-Subpart-B', '105-30', '105-30-a']
         self.assertEqual(new_nodes_added, subpart_changes.keys())
 
         for l, n in subpart_changes.items():

--- a/tests/notice_build_tests.py
+++ b/tests/notice_build_tests.py
@@ -245,7 +245,7 @@ class NoticeBuildTest(TestCase):
 
         changes = notice['changes']['105-1-b'][0]
         self.assertEqual(changes['action'], 'PUT')
-        self.assertTrue(changes['node']['text'].startswith(
+        self.assertTrue(changes['node'].text.startswith(
             u'(b) This part carries out.'))
 
     def test_process_amendments_multiple_in_same_parent(self):
@@ -272,11 +272,11 @@ class NoticeBuildTest(TestCase):
 
         changes = notice['changes']['105-1-b'][0]
         self.assertEqual(changes['action'], 'PUT')
-        self.assertEqual(changes['node']['text'].strip(),
+        self.assertEqual(changes['node'].text.strip(),
                          u'(b) This part carries out.')
         changes = notice['changes']['105-1-c'][0]
         self.assertEqual(changes['action'], 'PUT')
-        self.assertTrue(changes['node']['text'].strip(),
+        self.assertTrue(changes['node'].text.strip(),
                         u'(c) More stuff')
 
     def test_process_amendments_restart_new_section(self):
@@ -386,7 +386,7 @@ class NoticeBuildTest(TestCase):
             self.assertEqual(n['action'], 'POST')
 
         self.assertEqual(
-            subpart_changes['105-Subpart-B']['node']['node_type'], 'subpart')
+            subpart_changes['105-Subpart-B']['node'].node_type, 'subpart')
 
     def test_process_amendments_subpart(self):
         xml = self.new_subpart_xml()
@@ -537,7 +537,7 @@ class NoticeBuildTest(TestCase):
 
         reserve = notice_changes.changes['200-2-a'][0]
         self.assertEqual(reserve['action'], 'RESERVE')
-        self.assertEqual(reserve['node']['text'], u'[Reserved]')
+        self.assertEqual(reserve['node'].text, u'[Reserved]')
 
     def test_create_xml_changes_stars(self):
         labels_amended = [Amendment('PUT', '200-2-a')]

--- a/tests/notice_changes_tests.py
+++ b/tests/notice_changes_tests.py
@@ -78,9 +78,8 @@ class ChangesTests(TestCase):
             self.assertTrue(l in amends)
 
         for label, node in amends.items():
-            self.assertEqual(label, '-'.join(node['node']['label']))
+            self.assertEqual(label, '-'.join(node['node'].label))
             self.assertEqual(node['action'], 'POST')
-            self.assertFalse('children' in node['node'])
 
     def test_flatten_tree(self):
         tree = self.build_tree()

--- a/tests/notice_compiler_tests.py
+++ b/tests/notice_compiler_tests.py
@@ -406,7 +406,7 @@ class CompilerTests(TestCase):
     def test_replace_node_text(self):
         root = self.tree_with_paragraphs()
 
-        change = {'node': {'text': 'new text'}}
+        change = {'node': Node(text='new text')}
         reg_tree = compiler.RegulationTree(root)
 
         reg_tree.replace_node_text('205-2-a', change)
@@ -416,7 +416,7 @@ class CompilerTests(TestCase):
     def test_replace_node_title(self):
         root = self.tree_with_paragraphs()
 
-        change = {'node': {'title': 'new title'}}
+        change = {'node': Node(title='new title')}
         reg_tree = compiler.RegulationTree(root)
 
         reg_tree.replace_node_title('205-2-a', change)
@@ -429,7 +429,7 @@ class CompilerTests(TestCase):
         n2a.text = 'Previous keyterm. Remainder.'
         reg_tree = compiler.RegulationTree(root)
 
-        change = {'node': {'text': 'Replaced.'}}
+        change = {'node': Node(text='Replaced.')}
         reg_tree.replace_node_heading('205-2-a', change)
 
         changed_node = find(reg_tree.tree, '205-2-a')
@@ -541,17 +541,17 @@ class CompilerTests(TestCase):
 
         change2a = {
             'action': 'PUT',
-            'node': {
-                'text': 'new text',
-                'label': ['205', '2', 'a'],
-                'node_type': 'regtext'}}
+            'node': Node(
+                text='new text',
+                label=['205', '2', 'a'],
+                node_type=Node.REGTEXT)}
 
         change2a1 = {
             'action': 'PUT',
-            'node': {
-                'text': '2a1 text',
-                'label': ['205', '2', 'a', '1'],
-                'node_type': 'regtext'}}
+            'node': Node(
+                text='2a1 text',
+                label=['205', '2', 'a', '1'],
+                node_type=Node.REGTEXT)}
 
         notice_changes = {
             '205-2-a-1': [change2a1],
@@ -571,10 +571,10 @@ class CompilerTests(TestCase):
         change2a = {
             'action': 'PUT',
             'field': '[text]',
-            'node': {
-                'text': 'new text',
-                'label': ['205', '2', 'a'],
-                'node_type': 'regtext'}}
+            'node': Node(
+                text='new text',
+                label=['205', '2', 'a'],
+                node_type=Node.REGTEXT)}
 
         notice_changes = {'205-2-a': [change2a]}
         reg = compiler.compile_regulation(root, notice_changes)
@@ -585,11 +585,11 @@ class CompilerTests(TestCase):
     def test_compile_reg_keep_root(self):
         root = self.tree_with_paragraphs()
         change2 = {'action': 'KEEP',
-                   'node': {'text': '* * *', 'label': ['205', '2'],
-                            'node_type': 'regtext'}}
+                   'node': Node(text='* * *', label=['205', '2'],
+                            node_type=Node.REGTEXT)}
         change2a = {'action': 'PUT',
-                    'node': {'text': '(a) A Test', 'label': ['205', '2', 'a'],
-                             'node_type': 'regtext'}}
+                    'node': Node(text='(a) A Test', label=['205', '2', 'a'],
+                             node_type=Node.REGTEXT)}
 
         notice_changes = {'205-2': [change2], '205-2-a': [change2a]}
         reg = compiler.compile_regulation(root, notice_changes)
@@ -607,14 +607,14 @@ class CompilerTests(TestCase):
     def test_compile_reg_keep_child(self):
         root = self.tree_with_paragraphs()
         change2 = {'action': 'PUT',
-                   'node': {'text': 'n2n2', 'label': ['205', '2'],
-                            'node_type': 'regtext'}}
+                   'node': Node(text='n2n2', label=['205', '2'],
+                            node_type=Node.REGTEXT)}
         change2a = {'action': 'KEEP',
-                    'node': {'text': '(a) * * *', 'label': ['205', '2', 'a'],
-                             'node_type': 'regtext'}}
+                    'node': Node(text='(a) * * *', label=['205', '2', 'a'],
+                             node_type=Node.REGTEXT)}
         change2b = {'action': 'PUT',
-                    'node': {'text': '(b) A Test', 'label': ['205', '2', 'b'],
-                             'node_type': 'regtext'}}
+                    'node': Node(text='(b) A Test', label=['205', '2', 'b'],
+                             node_type=Node.REGTEXT)}
 
         notice_changes = {'205-2': [change2], '205-2-a': [change2a],
                           '205-2-b': [change2b]}
@@ -631,10 +631,10 @@ class CompilerTests(TestCase):
         root = self.tree_with_paragraphs()
         change2a1 = {
             'action': 'POST',
-            'node': {
-                'text': '2a1 text',
-                'label': ['205', '2', 'a', '1'],
-                'node_type': 'regtext'}}
+            'node': Node(
+                text='2a1 text',
+                label=['205', '2', 'a', '1'],
+                node_type=Node.REGTEXT)}
 
         notice_changes = {'205-2-a-1': [change2a1]}
         reg = compiler.compile_regulation(root, notice_changes)
@@ -655,10 +655,10 @@ class CompilerTests(TestCase):
         change = {
             'action': 'POST',
             'subpart': ['205', 'Subpart', 'B'],
-            'node': {
-                'text': '2 text',
-                'label': ['205', '2'],
-                'node_type': 'regtext'}}
+            'node': Node(
+                text='2 text',
+                label=['205', '2'],
+                node_type=Node.REGTEXT)}
 
         notice_changes = {'205-2': [change]}
         reg = compiler.compile_regulation(root, notice_changes)
@@ -671,10 +671,10 @@ class CompilerTests(TestCase):
         change = {
             'action': 'POST',
             'subpart': ['205', 'Subpart', 'B'],
-            'node': {
-                'text': '2 text',
-                'label': ['205', '2'],
-                'node_type': 'regtext'}}
+            'node': Node(
+                text='2 text',
+                label=['205', '2'],
+                node_type=Node.REGTEXT)}
 
         notice_changes = {'205-2': [change]}
         reg = compiler.compile_regulation(root, notice_changes)
@@ -885,9 +885,9 @@ class CompilerTests(TestCase):
         changes = {
             '205-2-a': [
                 {'action': 'MOVE', 'destination': ['205', '2', 'b']},
-                {'action': 'POST', 'node': {'text': 'aaa',
-                                            'label': ['205', '2', 'a'],
-                                            'node_type': Node.REGTEXT}}],
+                {'action': 'POST', 'node': Node(text='aaa',
+                                            label=['205', '2', 'a'],
+                                            node_type=Node.REGTEXT)}],
             '205-2-b': [{'action': 'DELETE'}]}
 
         class SortedKeysDict(object):

--- a/tests/tree_xml_parser_appendices_tests.py
+++ b/tests/tree_xml_parser_appendices_tests.py
@@ -663,8 +663,3 @@ class AppendixProcessorTest(TestCase):
         a = appendix.children[0]
         self.assertEqual(['1111', 'AA1', 'a'], a.label)
 
-    def test_parsed_title(self):
-
-
-        match = parsed_title(text, appendix_letter)
-    

--- a/tests/tree_xml_parser_appendices_tests.py
+++ b/tests/tree_xml_parser_appendices_tests.py
@@ -384,6 +384,9 @@ class AppendicesTest(TestCase):
         title = u'Part III—Construction Period'
         self.assertEqual(('III', 2), appendices.title_label_pair(title, 'A', '1000'))
 
+        title = u'Appendix DC-3(A) to Part 1000'
+        self.assertEqual(('3(A)', 2), appendices.title_label_pair(title, 'DC', '1000'))
+
     def test_title_label_pair_parens(self):
         title = u'G-13(A)—Has No parent'
         self.assertEqual(('13(A)', 2), appendices.title_label_pair(title, 'G', '1000'))
@@ -660,3 +663,8 @@ class AppendixProcessorTest(TestCase):
         a = appendix.children[0]
         self.assertEqual(['1111', 'AA1', 'a'], a.label)
 
+    def test_parsed_title(self):
+
+
+        match = parsed_title(text, appendix_letter)
+    

--- a/tests/tree_xml_parser_appendices_tests.py
+++ b/tests/tree_xml_parser_appendices_tests.py
@@ -134,7 +134,7 @@ class AppendicesTest(TestCase):
             <HD SOURCE="HD3">I. Remains Header</HD>
             <P>1. Content tent</P>
         </APPENDIX>"""
-        appendix = appendices.process_appendix(etree.fromstring(xml), 1111)
+        appendix = appendices.process_appendix(etree.fromstring(xml), '1111')
         self.assertEqual(1, len(appendix.children))
         a1 = appendix.children[0]
 
@@ -401,6 +401,9 @@ class AppendicesTest(TestCase):
         title = u'G-13And Some Smashed Text'
         self.assertEqual(('13', 2), appendices.title_label_pair(title, 'G', '1000'))
 
+    def test_title_label_pair_roman(self):
+        title = u'IX. Sample Page for Statement of Record —1010.102(e)'
+        self.assertEqual(('IX', 2), appendices.title_label_pair(title, 'A', '1010'))
 
 class AppendixProcessorTest(TestCase):
     def setUp(self):
@@ -662,4 +665,3 @@ class AppendixProcessorTest(TestCase):
 
         a = appendix.children[0]
         self.assertEqual(['1111', 'AA1', 'a'], a.label)
-

--- a/tests/tree_xml_parser_interpretations_tests.py
+++ b/tests/tree_xml_parser_interpretations_tests.py
@@ -26,11 +26,6 @@ class InterpretationsTest(TestCase):
         marker = interpretations.get_first_interp_marker(text)
         self.assertEqual(marker, '<E T="03">1</E>')
 
-    def test_interpretation_markers_none(self):
-        text = '(iv) Kiwis and Mangos'
-        marker = interpretations.get_first_interp_marker(text)
-        self.assertEqual(marker, None)
-
     def test_interpretation_markers_stars_no_period(self):
         for marker in ('4 ', 'iv  ', 'A\t'):
             text = marker + '* * *'
@@ -41,6 +36,12 @@ class InterpretationsTest(TestCase):
             found_marker = interpretations.get_first_interp_marker(text)
             self.assertEqual(None, found_marker)
 
+    def test_interpretation_markers_parenthesis(self):
+        text = u'(b) Some text here.'
+        found_marker = interpretations.get_first_interp_marker(text)
+        print found_marker
+        self.assertEqual("b", found_marker)
+        
     def test_build_supplement_tree(self):
         """Integration test"""
         xml = """<APPENDIX>

--- a/tests/tree_xml_parser_interpretations_tests.py
+++ b/tests/tree_xml_parser_interpretations_tests.py
@@ -39,7 +39,6 @@ class InterpretationsTest(TestCase):
     def test_interpretation_markers_parenthesis(self):
         text = u'(b) Some text here.'
         found_marker = interpretations.get_first_interp_marker(text)
-        print found_marker
         self.assertEqual("b", found_marker)
         
     def test_build_supplement_tree(self):
@@ -340,13 +339,32 @@ class InterpretationsTest(TestCase):
         while stack.size() > 1:
             stack.unwind()
         i1 = stack.m_stack[0][0][1]
+        self.assertEqual(1, len(i1.children))
+        i1i = i1.children[0]
+        self.assertEqual(0, len(i1i.children))
+        self.assertEqual(i1i.text.strip(), "i. iii\n\nHowdy Howdy")
+
+    def test_process_inner_child_depth_spec(self):
+        xml = """
+            <ROOT>
+                <HD>Title</HD>
+                <P depth="1">1. 111</P>
+                <P depth="2">i. iii</P>
+                <P depth="1">Howdy Howdy</P>
+            </ROOT>"""
+        node = etree.fromstring(xml).xpath('//HD')[0]
+        stack = tree_utils.NodeStack()
+        interpretations.process_inner_children(stack, node)
+        while stack.size() > 1:
+            stack.unwind()
+        i1 = stack.m_stack[0][0][1]
         i2 = stack.m_stack[0][1][1]
         self.assertEqual(1, len(i1.children))
         i1i = i1.children[0]
         self.assertEqual(0, len(i1i.children))
         self.assertEqual(i1i.text.strip(), "i. iii")
         self.assertEqual(i2.text.strip(), "Howdy Howdy")
-
+        
     def test_process_inner_child_has_citation(self):
         xml = """
         <ROOT>

--- a/tests/tree_xml_parser_reg_text_tests.py
+++ b/tests/tree_xml_parser_reg_text_tests.py
@@ -18,26 +18,24 @@ class RegTextTest(TestCase):
         """
         #from nose.tools import set_trace; set_trace();
         node = reg_text.build_from_section('8675', etree.fromstring(xml))[0]
-        self.assertEqual(2, len(node.children))
+        self.assertEqual(1, len(node.children))
         self.assertEqual(['8675', '309'], node.label)
 
         child1 = node.children[0]
-        child2 = node.children[1]
 
-        self.assertEqual('Some content about this section.', child1.text.strip())
-        self.assertEqual('(a) something something', child2.text.strip())
+        self.assertEqual('Some content about this section.', node.text.strip())
+        self.assertEqual('(a) something something', child1.text.strip())
         self.assertEqual([], child1.children)
-        self.assertEqual([], child2.children)
-        self.assertEqual(['8675', '309', 'a'], child2.label)
+        self.assertEqual(['8675', '309', 'a'], child1.label)
 
     def test_build_from_section_unnumbered_defs(self):
         xml = u"""
             <SECTION>
                 <SECTNO>§ 8675.309</SECTNO>
                 <SUBJECT>Definitions.</SUBJECT>
-                <P>(a) This is what things mean:</P>
-                <P>foo means bar</P>
-                <P>bop means baz</P>
+                <P depth="1">(a) This is what things mean:</P>
+                <P depth="1">foo means bar</P>
+                <P depth="1">bop means baz</P>
             </SECTION>
         """
         node = reg_text.build_from_section('8675', etree.fromstring(xml))[0]
@@ -59,7 +57,6 @@ class RegTextTest(TestCase):
         self.assertEqual('bop means baz', child.text.strip())
         self.assertEqual(0, len(child.children))
         self.assertEqual(['8675', '309', 'Bop'], child.label)
-
 
     def test_build_from_section_collapsed_level(self):
         xml = u"""


### PR DESCRIPTION
This PR restores some of the previous behavior surrounding markerless paragraphs.

If a manual hierarchy is not specified, markerless paragraphs will generally be appended to the previous nodes and/or to the parent node in the case of paragraphs that are the first child.

Manual hierarchy can now be specified in CFR XML as well, with the "depth" attribute, for example: `<P depth="1">foo</P>`.

There is now a `FR_NOTICE_OVERRIDES` setting that will override values in the FR notice JSON. This is necessary for Z's 2015-18239 effective date modifications. For example:

```
FR_NOTICE_OVERRIDES = {
    '2015-18239': {
        'dates': 'The amendments in this final rule are effective on '
                 'October 3, 2015. The effective date of 78 FR 79730, '
                 '79 FR 65299, and 80 FR 8767 has been delayed until '
                 'October 3, 2015',
    }
}
```

This is needed to get a clean, correct parse of Z (and likely other regs as well).

This also includes the changes in #296 and addresses @cmc333333's concerns from that PR.
