### PR TITLE
Move REISSUANCES and keep tagged_text

### DIFF
--- a/regparser/default_settings.py
+++ b/regparser/default_settings.py
@@ -104,7 +104,7 @@ APPENDIX_IGNORE_SUBHEADER_LABEL = {}
 PARAGRAPH_HIERARCHY = {'ALL':[]}
 
 # which notices are complete reissuances
-REISSUANCES = ['2013-01737', '2012-14047', '2012-14061', '2012-14062']
+REISSUANCES = []
 
 # It may be necessary to override the 'effective_on', 'dates', etc that
 # are fetched from the Federal Register initially, before the XML is

--- a/regparser/tree/struct.py
+++ b/regparser/tree/struct.py
@@ -15,7 +15,7 @@ class Node(object):
     INTERP_MARK = 'Interp'
 
     def __init__(self, text='', children=[], label=[], title=None,
-                 node_type=REGTEXT, source_xml=None):
+                 node_type=REGTEXT, source_xml=None, tagged_text=''):
 
         self.text = unicode(text)
 
@@ -28,6 +28,7 @@ class Node(object):
         self.node_type = node_type
         self.source_xml = source_xml
         self.marker = None
+        self.tagged_text = tagged_text
 
     def __repr__(self):
         return (("Node( text = %s, children = %s, label = %s, title = %s, "

--- a/regparser/tree/xml_parser/appendices.py
+++ b/regparser/tree/xml_parser/appendices.py
@@ -176,6 +176,7 @@ class AppendixProcessor(object):
             # else:
             node = Node(mtext, node_type=Node.APPENDIX,
                         label=[initial_marker(mtext)[0]])
+            node.tagged_text = tagged_text
             self.nodes.append(node)
 
     def paragraph_no_marker(self, text):

--- a/regparser/tree/xml_parser/reg_text.py
+++ b/regparser/tree/xml_parser/reg_text.py
@@ -306,7 +306,8 @@ def build_from_section(reg_part, section_xml):
                     m_stack.add(1 + depth, node)
         else:
             logging.error('Manual hierarchy length does not match node list length!'
-                          ' ({0} nodes but {1} provided)'.format(len(nodes), len(depths)))
+                          ' ({0} nodes but {1} provided, {2})'.format(
+                              len(nodes), len(depths), [n.label[0] for n in nodes]))
 
     elif nodes and not manual_hierarchy:
         logging.warning('Could not determine depth when parsing {0}:\n{1}'.format(section_no_without_marker, [n.label[0] for n in nodes]))


### PR DESCRIPTION
This PR moves `REISSUANCES` to regs-config and keeps the `tagged_text` around on the Node in appendices for use by layers later on.