### PR TITLE
Write notices separately for each applicable regulation

### DIFF
--- a/regparser/api_writer.py
+++ b/regparser/api_writer.py
@@ -141,8 +141,8 @@ class Client:
         return self.writer_class(
             "layer/%s/%s/%s" % (layer_name, label, doc_number))
 
-    def notice(self, doc_number):
-        return self.writer_class("notice/%s" % doc_number)
+    def notice(self, label, doc_number):
+        return self.writer_class("notice/%s/%s" % (label, doc_number))
 
     def diff(self, label, old_version, new_version):
         return self.writer_class("diff/%s/%s/%s" % (label, old_version,

--- a/regparser/builder.py
+++ b/regparser/builder.py
@@ -89,7 +89,8 @@ class Builder(object):
         for notice in self.notices:
             #  No need to carry this around
             del notice['meta']
-            self.writer.notice(self.cfr_part, notice['document_number']).write(notice)
+            self.writer.notice(
+                self.cfr_part, notice['document_number']).write(notice)
 
     def write_regulation(self, reg_tree):
         self.writer.regulation(self.cfr_part, self.doc_number).write(reg_tree)

--- a/regparser/builder.py
+++ b/regparser/builder.py
@@ -89,7 +89,7 @@ class Builder(object):
         for notice in self.notices:
             #  No need to carry this around
             del notice['meta']
-            self.writer.notice(notice['document_number']).write(notice)
+            self.writer.notice(self.cfr_part, notice['document_number']).write(notice)
 
     def write_regulation(self, reg_tree):
         self.writer.regulation(self.cfr_part, self.doc_number).write(reg_tree)

--- a/tests/api_writer_tests.py
+++ b/tests/api_writer_tests.py
@@ -224,8 +224,8 @@ class ClientTest(TestCase):
 
     def test_notice(self):
         client = Client()
-        reg_writer = client.notice("docdoc")
-        self.assertEqual("notice/docdoc", reg_writer.path)
+        reg_writer = client.notice("111", "docdoc")
+        self.assertEqual("notice/111/docdoc", reg_writer.path)
 
     def test_diff(self):
         client = Client()


### PR DESCRIPTION
This PR allows the eCFR parser to write notices to cfpb/regulations-core#62. The PR in regulations-core provides explanation for this change.

*THIS IS A BREAKING CHANGE* that requires cfpb/regulations-core#62.

![atomicbomb](https://cloud.githubusercontent.com/assets/10562538/11691356/9d01b8a6-9e68-11e5-9da0-7ad5c9e58a70.gif)