### PR TITLE
sometimes there are unescaped entities which causes lxml to crash

### DIFF
--- a/regparser/api_writer.py
+++ b/regparser/api_writer.py
@@ -12,6 +12,8 @@ from git.exc import InvalidGitRepositoryError
 
 from lxml.etree import Element, SubElement
 from lxml.etree import tostring, fromstring
+from lxml.etree import XMLSyntaxError
+from xml.sax.saxutils import escape
 
 import requests
 
@@ -596,7 +598,11 @@ class XMLWriteContent:
             text = self.apply_layers(root)
             if text.startswith('!'):
                 text = ''
-            content = fromstring('<content>' + text + '</content>')
+            try:
+                content = fromstring('<content>' + text + '</content>')
+            except XMLSyntaxError:
+                content = fromstring('<content>MISSING CONTENT</content>')
+                    
             # graphics are special since they're not really inlined
             if root.label_id() in self.layers['graphics']:
                 graphics = XMLWriteContent.apply_graphics(self.layers['graphics'][root.label_id()])
@@ -622,7 +628,10 @@ class XMLWriteContent:
             text = self.apply_layers(root)
             if text.startswith('!'):
                 text = ''
-            content = fromstring('<content>' + text + '</content>')
+            try:
+                content = fromstring('<content>' + escape(text) + '</content>')
+            except XMLSyntaxError:
+                content = fromstring('<content>MISSING CONTENT</content>')
 
             # graphics are special since they're not really inlined
             if root.label_id() in self.layers['graphics']:


### PR DESCRIPTION
So put some try/except blocks around that.